### PR TITLE
Remove ai-chat-boilerplate from profile Highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,15 +78,4 @@
       <img src="https://img.shields.io/github/stars/nathanssantos/pure-components?style=flat-square" />
     </td>
   </tr>
-  <tr>
-    <td align="center" width="600" colspan="2">
-      <a href="https://github.com/nathanssantos/ai-chat-boilerplate">
-        <strong>ai-chat-boilerplate</strong>
-      </a>
-      <br /><br />
-      Electron-based AI chat boilerplate with multi-provider support (OpenAI, Anthropic). Built with React, TypeScript, and tRPC.
-      <br /><br />
-      <img src="https://img.shields.io/github/stars/nathanssantos/ai-chat-boilerplate?style=flat-square" />
-    </td>
-  </tr>
 </table>


### PR DESCRIPTION
Repo still has leftover code from the old MarketMind it was based on — pulling it from the profile cover until reviewed. AI/LLMs badge kept (legit via Clint/MarketMind/Claude Code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)