### PR TITLE
Responsive/centered layout fix + tsparticles v4 + extract Section/ButtonLink

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,15 +8,15 @@
       "name": "nathanssantos",
       "version": "0.1.0",
       "dependencies": {
+        "@tsparticles/engine": "^4.3.2",
+        "@tsparticles/react": "^4.3.2",
+        "@tsparticles/slim": "^4.3.2",
         "next": "16.2.10",
         "next-intl": "^4.13.2",
         "next-themes": "^0.4.6",
         "react": "19.2.7",
         "react-dom": "19.2.7",
-        "react-icons": "^4.6.0",
-        "react-particles": "^2.5.3",
-        "tsparticles": "^2.5.3",
-        "tsparticles-engine": "^2.12.0"
+        "react-icons": "^4.6.0"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.3.2",
@@ -2209,6 +2209,574 @@
         "@tailwindcss/oxide": "4.3.2",
         "postcss": "^8.5.15",
         "tailwindcss": "4.3.2"
+      }
+    },
+    "node_modules/@tsparticles/animation-utils": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/animation-utils/-/animation-utils-4.3.2.tgz",
+      "integrity": "sha512-x4i/F24myZsk/qJEkREbOpzoWJtAbW8cL0Pan0Y5SdmKkG0dyLHw/fTG2uttIA3eeXhPH8JN648pSZMvbNJItw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/matteobruni"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/tsparticles"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/matteobruni"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2"
+      }
+    },
+    "node_modules/@tsparticles/basic": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/basic/-/basic-4.3.2.tgz",
+      "integrity": "sha512-8XTjwZqrxdfT1WUBvhjip1uksdeYBG0k0mr87vebIs7EwCSO//Rau1XYrHE69mSBwYvIqEhLNcwAixHbypG44Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/matteobruni"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/tsparticles"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/matteobruni"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "4.3.2",
+        "@tsparticles/plugin-blend": "4.3.2",
+        "@tsparticles/plugin-hex-color": "4.3.2",
+        "@tsparticles/plugin-hsl-color": "4.3.2",
+        "@tsparticles/plugin-move": "4.3.2",
+        "@tsparticles/plugin-rgb-color": "4.3.2",
+        "@tsparticles/shape-circle": "4.3.2",
+        "@tsparticles/updater-opacity": "4.3.2",
+        "@tsparticles/updater-out-modes": "4.3.2",
+        "@tsparticles/updater-paint": "4.3.2",
+        "@tsparticles/updater-size": "4.3.2"
+      }
+    },
+    "node_modules/@tsparticles/canvas-utils": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/canvas-utils/-/canvas-utils-4.3.2.tgz",
+      "integrity": "sha512-SN0O1sFhaCH5NfkZK9KawY9dK8YhiDqwPbqv7/Y9/oKmdreXQ2GSkaPOHOGmVDAkl3LYTI8Ip/JfNZaJ1GxDJQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/matteobruni"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/tsparticles"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/matteobruni"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2"
+      }
+    },
+    "node_modules/@tsparticles/engine": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/engine/-/engine-4.3.2.tgz",
+      "integrity": "sha512-k4U7uahhxt7bPjEPHu+qrJXjHRysy/QMN+2/KK4d0/V7CElt5/oeR+H9QB95Osy/PtUCCi6EH/LS7k0443qlJA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/matteobruni"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/tsparticles"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/matteobruni"
+        }
+      ],
+      "hasInstallScript": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsparticles/interaction-external-attract": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-attract/-/interaction-external-attract-4.3.2.tgz",
+      "integrity": "sha512-dMODX9wNrro+E4mjooFSpA9GsGTecqaNzBaSxHY4wUd4Vqlwms3nGfcLs8mr5C6oOz9+i8ADClN30HbcK1n6hw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2",
+        "@tsparticles/plugin-interactivity": "4.3.2"
+      }
+    },
+    "node_modules/@tsparticles/interaction-external-bounce": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-bounce/-/interaction-external-bounce-4.3.2.tgz",
+      "integrity": "sha512-xRa4HT1TZ2T+TdAr3Y6P99hDC3vfvz04QPFr7QaZxnkZDpqeXSzT3VdWa4+PhWnV8s+VzmDI4MWqk5b6dfyq4w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2",
+        "@tsparticles/plugin-interactivity": "4.3.2"
+      }
+    },
+    "node_modules/@tsparticles/interaction-external-bubble": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-bubble/-/interaction-external-bubble-4.3.2.tgz",
+      "integrity": "sha512-DkFnv+ydwe/ZFsex7S1fmBfaDNFXIZCbBxEmYWylKkiWcm1yTe5A5YzqkEdQZC7tglppf3Jdou9cQXzwoD5HrA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2",
+        "@tsparticles/plugin-interactivity": "4.3.2"
+      }
+    },
+    "node_modules/@tsparticles/interaction-external-connect": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-connect/-/interaction-external-connect-4.3.2.tgz",
+      "integrity": "sha512-hZI01JrXCJLVO4l8jq5nB/6U+ghE7SjOoqbUqR8sM/PiNA6jQupibweyhvK8R/4Rh+soAYZHZ1uBFxXwpXOb5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/canvas-utils": "4.3.2"
+      },
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2",
+        "@tsparticles/plugin-interactivity": "4.3.2"
+      }
+    },
+    "node_modules/@tsparticles/interaction-external-destroy": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-destroy/-/interaction-external-destroy-4.3.2.tgz",
+      "integrity": "sha512-HNb4zbZQwMIurFGT/TeyJ2NVlIrBRgVuc93mRIWIA1vOdFZMEkkE1mgP55sOii/vASp/UAB+dXaaJP37gaC46w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2",
+        "@tsparticles/plugin-interactivity": "4.3.2"
+      }
+    },
+    "node_modules/@tsparticles/interaction-external-grab": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-grab/-/interaction-external-grab-4.3.2.tgz",
+      "integrity": "sha512-WITZJ4u36yPEcnVljpfWhMc8aJn07Zz8Eq7u5umERBTKF0QdLrMWseM3HgSv7AOV04fp86CDciVLOa2Ivdwcrw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/canvas-utils": "4.3.2"
+      },
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2",
+        "@tsparticles/plugin-interactivity": "4.3.2"
+      }
+    },
+    "node_modules/@tsparticles/interaction-external-parallax": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-parallax/-/interaction-external-parallax-4.3.2.tgz",
+      "integrity": "sha512-sdP7OI7pMbKfvI819M9Ini3Lm8/OR3Lt3jXWb7gP8bDUxZ0zbWa5gmkZjWwyW8bFzBMssjSY1J1GhkZzTMv6Yg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2",
+        "@tsparticles/plugin-interactivity": "4.3.2"
+      }
+    },
+    "node_modules/@tsparticles/interaction-external-pause": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-pause/-/interaction-external-pause-4.3.2.tgz",
+      "integrity": "sha512-nuIoXWAFb1wVNk29iiGJHjN6XaPlUJjsLsF1Tl9QhKAlXvrXk08zZsU7QVJ4bzMhyQ94IZdzNAVPd4cvOhVrHQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2",
+        "@tsparticles/plugin-interactivity": "4.3.2"
+      }
+    },
+    "node_modules/@tsparticles/interaction-external-push": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-push/-/interaction-external-push-4.3.2.tgz",
+      "integrity": "sha512-2buFHr/73pdHMXaFPUFjdY0STWysvEGJpSYSAwmvt58WHVbM1z2XwBMpozQwRe15UNDw3H5ddeiVkIKuqwjZlQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2",
+        "@tsparticles/plugin-interactivity": "4.3.2"
+      }
+    },
+    "node_modules/@tsparticles/interaction-external-remove": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-remove/-/interaction-external-remove-4.3.2.tgz",
+      "integrity": "sha512-iJW2VuguF+cIUEHnrdFcVWTZMJnZ7j0q74Jut3FQy4XyGTzD2P8UCswbfpnZHQssGIPMupp7bHNIXOOchLTrtw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2",
+        "@tsparticles/plugin-interactivity": "4.3.2"
+      }
+    },
+    "node_modules/@tsparticles/interaction-external-repulse": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-repulse/-/interaction-external-repulse-4.3.2.tgz",
+      "integrity": "sha512-o0RyOjQROCqpJzjaMcNFew9afvJdKJB94E5XYoJCYK6Pwhp0BFMariXe91/yTdguIYrjUwJMQ5bvyBejP4Ygzw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2",
+        "@tsparticles/plugin-interactivity": "4.3.2"
+      }
+    },
+    "node_modules/@tsparticles/interaction-external-slow": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-slow/-/interaction-external-slow-4.3.2.tgz",
+      "integrity": "sha512-wMdbZ6xD0QQJ1W077iJvHyCJ2kKHpE4+/xu0B7ffTHesn6vYv4K+CWUVvBTwVC5sJVq4Q2Av974qOfxIhMY7ZQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2",
+        "@tsparticles/plugin-interactivity": "4.3.2"
+      }
+    },
+    "node_modules/@tsparticles/interaction-particles-attract": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-particles-attract/-/interaction-particles-attract-4.3.2.tgz",
+      "integrity": "sha512-X2GUryt0e5tkeQmIAt7QDqiq3OtNXE72QrM2a+T8E3T0Cvq9/UqrOtlCm6VKlel9OV2NAUi3BH84oCvOcqfYFg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2",
+        "@tsparticles/plugin-interactivity": "4.3.2"
+      }
+    },
+    "node_modules/@tsparticles/interaction-particles-collisions": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-particles-collisions/-/interaction-particles-collisions-4.3.2.tgz",
+      "integrity": "sha512-dLBgNXAdRJN2bFTYPEK3lvSeJFWOT1gv22aGOBatPPxLZ+mH5w3oH8LE2noa7tBpiyG4tVEzMzZUIdp57SemPg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2",
+        "@tsparticles/plugin-interactivity": "4.3.2"
+      }
+    },
+    "node_modules/@tsparticles/interaction-particles-links": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-particles-links/-/interaction-particles-links-4.3.2.tgz",
+      "integrity": "sha512-h0bZcpj2tFItovtzCMyHCqu2Fhz+/N9oXQctvmD9sf7C7eya26ZsISEgPqqFIAvdwLYhmQTk5fns4d/6Y7yRWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/canvas-utils": "4.3.2"
+      },
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2",
+        "@tsparticles/plugin-interactivity": "4.3.2"
+      }
+    },
+    "node_modules/@tsparticles/plugin-blend": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/plugin-blend/-/plugin-blend-4.3.2.tgz",
+      "integrity": "sha512-5iUDwzvcOtiaFvsbL3y+UzneGrlNwITB8HlNCfjp675wrg9xh7ILHa3/ZYHii1qC8gkKNva0w2N+wET9n+XWBQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2"
+      }
+    },
+    "node_modules/@tsparticles/plugin-easing-quad": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/plugin-easing-quad/-/plugin-easing-quad-4.3.2.tgz",
+      "integrity": "sha512-yrh6KSD+UEY8aW3hnfzVL84neUwCZ1ZqU/cj5jTHDQ7zFbYu8QA6zhR30kYHI645VmCaMjp+zuZ2ii6rwXsVIQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/matteobruni"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/tsparticles"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/matteobruni"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2"
+      }
+    },
+    "node_modules/@tsparticles/plugin-hex-color": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/plugin-hex-color/-/plugin-hex-color-4.3.2.tgz",
+      "integrity": "sha512-uRNSHx/d3hByVYAwPHKKoKxy7s0QujhNUpsgDuL92JODKCjCFm8SudbkW3STSXVznhY5bCcu4iAF+7zKVgVXCg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/matteobruni"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/tsparticles"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/matteobruni"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2"
+      }
+    },
+    "node_modules/@tsparticles/plugin-hsl-color": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/plugin-hsl-color/-/plugin-hsl-color-4.3.2.tgz",
+      "integrity": "sha512-kvRux8WnToyy9Dr8ROYvNDnE0HPW5h7x3wBROOghlazGYvYPO4nJBFvcmvvISRF6Ghsm9bzY255Qun2vACv2tA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/matteobruni"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/tsparticles"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/matteobruni"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2"
+      }
+    },
+    "node_modules/@tsparticles/plugin-interactivity": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/plugin-interactivity/-/plugin-interactivity-4.3.2.tgz",
+      "integrity": "sha512-GIOiyrSn2Zf+cWxLPeUeYG4qjSeGzDcocbSiLcAaPPjZ5J+D0LOBsrrb6qvqMvUj0qCkjKF4cIf7OgznhkdZkw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2"
+      }
+    },
+    "node_modules/@tsparticles/plugin-move": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/plugin-move/-/plugin-move-4.3.2.tgz",
+      "integrity": "sha512-8nSDxWhxVWl9JzX/fSZwz5ZVzEMMFJLF3vizjfag2zE+jc4Nidfs9ZOPrD4yxpKSfZiv1ZwJpoOhT2ch4sVTug==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2"
+      }
+    },
+    "node_modules/@tsparticles/plugin-rgb-color": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/plugin-rgb-color/-/plugin-rgb-color-4.3.2.tgz",
+      "integrity": "sha512-/4xZBlEWqqG7VscJzC2VimA62fxDboe4XO1+m8LeM2ytxrhEpNk14TeBJt+zCc8jBkFjpKOdmTZ0VYyuK4FtDQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/matteobruni"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/tsparticles"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/matteobruni"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2"
+      }
+    },
+    "node_modules/@tsparticles/react": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/react/-/react-4.3.2.tgz",
+      "integrity": "sha512-aCTqFkGBnT1BitrlmyjkR+FNQ+RKuO8UfhadLfW51YSHwTdR0erB1ZFab+wCout1SWGIR7mirRWfjwewxiDMeA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2",
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@tsparticles/shape-circle": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/shape-circle/-/shape-circle-4.3.2.tgz",
+      "integrity": "sha512-IOStpEafsK9vIZsXtrO1zpqF3pW5ydstD8db4omioAnoYFfKwbgyfkQz9l4pDnJy8636RbnQNVbYGlyxKuJ0cw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2"
+      }
+    },
+    "node_modules/@tsparticles/shape-emoji": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/shape-emoji/-/shape-emoji-4.3.2.tgz",
+      "integrity": "sha512-et8OLZpt1fJsBBEhb0NHp++MeMF3Q3VZq1JMzdaI6i1rCm8h8yfEbi96Izz+e1OFYKpY/qZfyVxrLnW33VYFJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/canvas-utils": "4.3.2"
+      },
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2"
+      }
+    },
+    "node_modules/@tsparticles/shape-image": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/shape-image/-/shape-image-4.3.2.tgz",
+      "integrity": "sha512-EtKkH7DMI+2rcF9n5VCJWKcyI/jX+B/OfucM/9MThG5qApqLBzfZvxRQRFG2agZKIHByGmXtfZyou4y2XPuq9g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2"
+      }
+    },
+    "node_modules/@tsparticles/shape-line": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/shape-line/-/shape-line-4.3.2.tgz",
+      "integrity": "sha512-ph8q+9vx8BxYb1JToPde6v0Vejfg+hPGEWYhD5J5orrLcxqjmGimbRd+ycFV+fgHcmFDzfzlVUtiR7U+F3mgNg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2"
+      }
+    },
+    "node_modules/@tsparticles/shape-polygon": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/shape-polygon/-/shape-polygon-4.3.2.tgz",
+      "integrity": "sha512-ebpHYQlk0khRXFtG1WWQIQSIedb23OEICWuhTAmh87lVkFkNeU5synyS6UqxSOXda098BiRnO++P69Sfq12E5w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2"
+      }
+    },
+    "node_modules/@tsparticles/shape-square": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/shape-square/-/shape-square-4.3.2.tgz",
+      "integrity": "sha512-U3q5TdvDclXSAM6ott4evZaWt00o+mEmO0RUsIGZR4W0DdaaZTa0zmeitQnM/wJnkwpXUqVWF3H88FS1MOy9ag==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2"
+      }
+    },
+    "node_modules/@tsparticles/shape-star": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/shape-star/-/shape-star-4.3.2.tgz",
+      "integrity": "sha512-i8AquyuaJ3GH3qsWIepVbsdxCM0Tl0ZFSmJni8AC+ly2Py7+Ig/uJpxM9oC5YkNdcAU6vosMgAS3xUobVQDvsg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2"
+      }
+    },
+    "node_modules/@tsparticles/slim": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/slim/-/slim-4.3.2.tgz",
+      "integrity": "sha512-VDCC1xod/Ak9Pn+OD/5AT6y3ccPR3n+EHQBZJKin81yYE/+POfNZ+tDSg/cMmrNBW6MFobKVJpp2kO0AoYFvrw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/matteobruni"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/tsparticles"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/matteobruni"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/basic": "4.3.2",
+        "@tsparticles/engine": "4.3.2",
+        "@tsparticles/interaction-external-attract": "4.3.2",
+        "@tsparticles/interaction-external-bounce": "4.3.2",
+        "@tsparticles/interaction-external-bubble": "4.3.2",
+        "@tsparticles/interaction-external-connect": "4.3.2",
+        "@tsparticles/interaction-external-destroy": "4.3.2",
+        "@tsparticles/interaction-external-grab": "4.3.2",
+        "@tsparticles/interaction-external-parallax": "4.3.2",
+        "@tsparticles/interaction-external-pause": "4.3.2",
+        "@tsparticles/interaction-external-push": "4.3.2",
+        "@tsparticles/interaction-external-remove": "4.3.2",
+        "@tsparticles/interaction-external-repulse": "4.3.2",
+        "@tsparticles/interaction-external-slow": "4.3.2",
+        "@tsparticles/interaction-particles-attract": "4.3.2",
+        "@tsparticles/interaction-particles-collisions": "4.3.2",
+        "@tsparticles/interaction-particles-links": "4.3.2",
+        "@tsparticles/plugin-easing-quad": "4.3.2",
+        "@tsparticles/plugin-interactivity": "4.3.2",
+        "@tsparticles/shape-emoji": "4.3.2",
+        "@tsparticles/shape-image": "4.3.2",
+        "@tsparticles/shape-line": "4.3.2",
+        "@tsparticles/shape-polygon": "4.3.2",
+        "@tsparticles/shape-square": "4.3.2",
+        "@tsparticles/shape-star": "4.3.2",
+        "@tsparticles/updater-life": "4.3.2",
+        "@tsparticles/updater-paint": "4.3.2",
+        "@tsparticles/updater-rotate": "4.3.2"
+      }
+    },
+    "node_modules/@tsparticles/updater-life": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/updater-life/-/updater-life-4.3.2.tgz",
+      "integrity": "sha512-RL3803nFKsCsGQavLSZyEiFWhto9R4+QQ/tsqt8PNmHOC7nmI96ZVGVXDknaSuCM4OwuwrDawIdrZUv6OSEFSQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2"
+      }
+    },
+    "node_modules/@tsparticles/updater-opacity": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/updater-opacity/-/updater-opacity-4.3.2.tgz",
+      "integrity": "sha512-Mw4WN/E+ZQQkL683/oyLkebDMpSpbqDRgx2GhMqWOQNTDby5RYG6wSrq0cGtg0aLZmkoYDYLz5Al7wjPfX0/LA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/animation-utils": "4.3.2"
+      },
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2"
+      }
+    },
+    "node_modules/@tsparticles/updater-out-modes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/updater-out-modes/-/updater-out-modes-4.3.2.tgz",
+      "integrity": "sha512-lGiYbrFGaAmBakCrEf3Xq5W+LzDkvfINav0MGxCe/acf7u3yvjOUkVH0Co1zc/ju43nU5U2ZO88Anqk4xKtoPA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2"
+      }
+    },
+    "node_modules/@tsparticles/updater-paint": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/updater-paint/-/updater-paint-4.3.2.tgz",
+      "integrity": "sha512-cp020EtLL0zjsILL1w07r8n8wmwzziuHwtQ0GqGaGq+SikrdoK6yT/sXbyAylJqDypNaloVy3NZMq4wNQtxLOg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2"
+      }
+    },
+    "node_modules/@tsparticles/updater-rotate": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/updater-rotate/-/updater-rotate-4.3.2.tgz",
+      "integrity": "sha512-vDp7sg+FQQ9NRY6Nh2Joccd5oqmv6W1Y0L56AWrxjc6wk29IRuVeRo1QuoqRLzqq/xLJBhsbkyKXZG0wiE8Blg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/animation-utils": "4.3.2"
+      },
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2"
+      }
+    },
+    "node_modules/@tsparticles/updater-size": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tsparticles/updater-size/-/updater-size-4.3.2.tgz",
+      "integrity": "sha512-U7YtYqH0MvALOS4Nr33soOFJ63n8qS9Xujl9BcNZnbmRBf4xgOnTC1TztMvGO19GANTBwq4QKsKQiwFlwAk4qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/animation-utils": "4.3.2"
+      },
+      "peerDependencies": {
+        "@tsparticles/engine": "4.3.2"
       }
     },
     "node_modules/@tybys/wasm-util": {
@@ -6923,34 +7491,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/react-particles": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/react-particles/-/react-particles-2.12.2.tgz",
-      "integrity": "sha512-Bo9DdrBRPFy8uiT7BA8P36Rdmz6GhB/RG9kkWUyZGIsS8AxWyuUjpVxw9Lr23K0LVE2aenAJ0vnqEbbLDpBgQw==",
-      "deprecated": "@tsparticles/react is the new version, please use that",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/matteobruni"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/tsparticles"
-        },
-        {
-          "type": "buymeacoffee",
-          "url": "https://www.buymeacoffee.com/matteobruni"
-        }
-      ],
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      },
-      "peerDependencies": {
-        "react": ">=16"
-      }
-    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -7761,565 +8301,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
-    },
-    "node_modules/tsparticles": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles/-/tsparticles-2.12.0.tgz",
-      "integrity": "sha512-aw77llkaEhcKYUHuRlggA6SB1Dpa814/nrStp9USGiDo5QwE1Ckq30QAgdXU6GRvnblUFsiO750ZuLQs5Y0tVw==",
-      "deprecated": "Please update to version 4.1.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/matteobruni"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/tsparticles"
-        },
-        {
-          "type": "buymeacoffee",
-          "url": "https://www.buymeacoffee.com/matteobruni"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0",
-        "tsparticles-interaction-external-trail": "^2.12.0",
-        "tsparticles-plugin-absorbers": "^2.12.0",
-        "tsparticles-plugin-emitters": "^2.12.0",
-        "tsparticles-slim": "^2.12.0",
-        "tsparticles-updater-destroy": "^2.12.0",
-        "tsparticles-updater-roll": "^2.12.0",
-        "tsparticles-updater-tilt": "^2.12.0",
-        "tsparticles-updater-twinkle": "^2.12.0",
-        "tsparticles-updater-wobble": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-basic": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-basic/-/tsparticles-basic-2.12.0.tgz",
-      "integrity": "sha512-pN6FBpL0UsIUXjYbiui5+IVsbIItbQGOlwyGV55g6IYJBgdTNXgFX0HRYZGE9ZZ9psEXqzqwLM37zvWnb5AG9g==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/matteobruni"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/tsparticles"
-        },
-        {
-          "type": "buymeacoffee",
-          "url": "https://www.buymeacoffee.com/matteobruni"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0",
-        "tsparticles-move-base": "^2.12.0",
-        "tsparticles-shape-circle": "^2.12.0",
-        "tsparticles-updater-color": "^2.12.0",
-        "tsparticles-updater-opacity": "^2.12.0",
-        "tsparticles-updater-out-modes": "^2.12.0",
-        "tsparticles-updater-size": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-engine": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-engine/-/tsparticles-engine-2.12.0.tgz",
-      "integrity": "sha512-ZjDIYex6jBJ4iMc9+z0uPe7SgBnmb6l+EJm83MPIsOny9lPpetMsnw/8YJ3xdxn8hV+S3myTpTN1CkOVmFv0QQ==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/matteobruni"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/tsparticles"
-        },
-        {
-          "type": "buymeacoffee",
-          "url": "https://www.buymeacoffee.com/matteobruni"
-        }
-      ],
-      "hasInstallScript": true,
-      "license": "MIT"
-    },
-    "node_modules/tsparticles-interaction-external-attract": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-interaction-external-attract/-/tsparticles-interaction-external-attract-2.12.0.tgz",
-      "integrity": "sha512-0roC6D1QkFqMVomcMlTaBrNVjVOpyNzxIUsjMfshk2wUZDAvTNTuWQdUpmsLS4EeSTDN3rzlGNnIuuUQqyBU5w==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-interaction-external-bounce": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-interaction-external-bounce/-/tsparticles-interaction-external-bounce-2.12.0.tgz",
-      "integrity": "sha512-MMcqKLnQMJ30hubORtdq+4QMldQ3+gJu0bBYsQr9BsThsh8/V0xHc1iokZobqHYVP5tV77mbFBD8Z7iSCf0TMQ==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-interaction-external-bubble": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-interaction-external-bubble/-/tsparticles-interaction-external-bubble-2.12.0.tgz",
-      "integrity": "sha512-5kImCSCZlLNccXOHPIi2Yn+rQWTX3sEa/xCHwXW19uHxtILVJlnAweayc8+Zgmb7mo0DscBtWVFXHPxrVPFDUA==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-interaction-external-connect": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-interaction-external-connect/-/tsparticles-interaction-external-connect-2.12.0.tgz",
-      "integrity": "sha512-ymzmFPXz6AaA1LAOL5Ihuy7YSQEW8MzuSJzbd0ES13U8XjiU3HlFqlH6WGT1KvXNw6WYoqrZt0T3fKxBW3/C3A==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-interaction-external-grab": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-interaction-external-grab/-/tsparticles-interaction-external-grab-2.12.0.tgz",
-      "integrity": "sha512-iQF/A947hSfDNqAjr49PRjyQaeRkYgTYpfNmAf+EfME8RsbapeP/BSyF6mTy0UAFC0hK2A2Hwgw72eT78yhXeQ==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-interaction-external-pause": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-interaction-external-pause/-/tsparticles-interaction-external-pause-2.12.0.tgz",
-      "integrity": "sha512-4SUikNpsFROHnRqniL+uX2E388YTtfRWqqqZxRhY0BrijH4z04Aii3YqaGhJxfrwDKkTQlIoM2GbFT552QZWjw==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-interaction-external-push": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-interaction-external-push/-/tsparticles-interaction-external-push-2.12.0.tgz",
-      "integrity": "sha512-kqs3V0dgDKgMoeqbdg+cKH2F+DTrvfCMrPF1MCCUpBCqBiH+TRQpJNNC86EZYHfNUeeLuIM3ttWwIkk2hllR/Q==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-interaction-external-remove": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-interaction-external-remove/-/tsparticles-interaction-external-remove-2.12.0.tgz",
-      "integrity": "sha512-2eNIrv4m1WB2VfSVj46V2L/J9hNEZnMgFc+A+qmy66C8KzDN1G8aJUAf1inW8JVc0lmo5+WKhzex4X0ZSMghBg==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-interaction-external-repulse": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-interaction-external-repulse/-/tsparticles-interaction-external-repulse-2.12.0.tgz",
-      "integrity": "sha512-rSzdnmgljeBCj5FPp4AtGxOG9TmTsK3AjQW0vlyd1aG2O5kSqFjR+FuT7rfdSk9LEJGH5SjPFE6cwbuy51uEWA==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-interaction-external-slow": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-interaction-external-slow/-/tsparticles-interaction-external-slow-2.12.0.tgz",
-      "integrity": "sha512-2IKdMC3om7DttqyroMtO//xNdF0NvJL/Lx7LDo08VpfTgJJozxU+JAUT8XVT7urxhaDzbxSSIROc79epESROtA==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-interaction-external-trail": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-interaction-external-trail/-/tsparticles-interaction-external-trail-2.12.0.tgz",
-      "integrity": "sha512-LKSapU5sPTaZqYx+y5VJClj0prlV7bswplSFQaIW1raXkvsk45qir2AVcpP5JUhZSFSG+SwsHr+qCgXhNeN1KA==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-interaction-particles-attract": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-interaction-particles-attract/-/tsparticles-interaction-particles-attract-2.12.0.tgz",
-      "integrity": "sha512-Hl8qwuwF9aLq3FOkAW+Zomu7Gb8IKs6Y3tFQUQScDmrrSCaeRt2EGklAiwgxwgntmqzL7hbMWNx06CHHcUQKdQ==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-interaction-particles-collisions": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-interaction-particles-collisions/-/tsparticles-interaction-particles-collisions-2.12.0.tgz",
-      "integrity": "sha512-Se9nPWlyPxdsnHgR6ap4YUImAu3W5MeGKJaQMiQpm1vW8lSMOUejI1n1ioIaQth9weKGKnD9rvcNn76sFlzGBA==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-interaction-particles-links": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-interaction-particles-links/-/tsparticles-interaction-particles-links-2.12.0.tgz",
-      "integrity": "sha512-e7I8gRs4rmKfcsHONXMkJnymRWpxHmeaJIo4g2NaDRjIgeb2AcJSWKWZvrsoLnm7zvaf/cMQlbN6vQwCixYq3A==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-move-base": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-move-base/-/tsparticles-move-base-2.12.0.tgz",
-      "integrity": "sha512-oSogCDougIImq+iRtIFJD0YFArlorSi8IW3HD2gO3USkH+aNn3ZqZNTqp321uB08K34HpS263DTbhLHa/D6BWw==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-move-parallax": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-move-parallax/-/tsparticles-move-parallax-2.12.0.tgz",
-      "integrity": "sha512-58CYXaX8Ih5rNtYhpnH0YwU4Ks7gVZMREGUJtmjhuYN+OFr9FVdF3oDIJ9N6gY5a5AnAKz8f5j5qpucoPRcYrQ==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-particles.js": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-particles.js/-/tsparticles-particles.js-2.12.0.tgz",
-      "integrity": "sha512-LyOuvYdhbUScmA4iDgV3LxA0HzY1DnOwQUy3NrPYO393S2YwdDjdwMod6Btq7EBUjg9FVIh+sZRizgV5elV2dg==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/matteobruni"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/tsparticles"
-        },
-        {
-          "type": "buymeacoffee",
-          "url": "https://www.buymeacoffee.com/matteobruni"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-plugin-absorbers": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-plugin-absorbers/-/tsparticles-plugin-absorbers-2.12.0.tgz",
-      "integrity": "sha512-2CkPreaXHrE5VzFlxUKLeRB5t66ff+3jwLJoDFgQcp+R4HOEITo0bBZv2DagGP0QZdYN4grpnQzRBVdB4d1rWA==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-plugin-easing-quad": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-plugin-easing-quad/-/tsparticles-plugin-easing-quad-2.12.0.tgz",
-      "integrity": "sha512-2mNqez5pydDewMIUWaUhY5cNQ80IUOYiujwG6qx9spTq1D6EEPLbRNAEL8/ecPdn2j1Um3iWSx6lo340rPkv4Q==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/matteobruni"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/tsparticles"
-        },
-        {
-          "type": "buymeacoffee",
-          "url": "https://www.buymeacoffee.com/matteobruni"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-plugin-emitters": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-plugin-emitters/-/tsparticles-plugin-emitters-2.12.0.tgz",
-      "integrity": "sha512-fbskYnaXWXivBh9KFReVCfqHdhbNQSK2T+fq2qcGEWpwtDdgujcaS1k2Q/xjZnWNMfVesik4IrqspcL51gNdSA==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-shape-circle": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-shape-circle/-/tsparticles-shape-circle-2.12.0.tgz",
-      "integrity": "sha512-L6OngbAlbadG7b783x16ns3+SZ7i0SSB66M8xGa5/k+YcY7zm8zG0uPt1Hd+xQDR2aNA3RngVM10O23/Lwk65Q==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-shape-image": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-shape-image/-/tsparticles-shape-image-2.12.0.tgz",
-      "integrity": "sha512-iCkSdUVa40DxhkkYjYuYHr9MJGVw+QnQuN5UC+e/yBgJQY+1tQL8UH0+YU/h0GHTzh5Sm+y+g51gOFxHt1dj7Q==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-shape-line": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-shape-line/-/tsparticles-shape-line-2.12.0.tgz",
-      "integrity": "sha512-RcpKmmpKlk+R8mM5wA2v64Lv1jvXtU4SrBDv3vbdRodKbKaWGGzymzav1Q0hYyDyUZgplEK/a5ZwrfrOwmgYGA==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-shape-polygon": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-shape-polygon/-/tsparticles-shape-polygon-2.12.0.tgz",
-      "integrity": "sha512-5YEy7HVMt1Obxd/jnlsjajchAlYMr9eRZWN+lSjcFSH6Ibra7h59YuJVnwxOxAobpijGxsNiBX0PuGQnB47pmA==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-shape-square": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-shape-square/-/tsparticles-shape-square-2.12.0.tgz",
-      "integrity": "sha512-33vfajHqmlODKaUzyPI/aVhnAOT09V7nfEPNl8DD0cfiNikEuPkbFqgJezJuE55ebtVo7BZPDA9o7GYbWxQNuw==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-shape-star": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-shape-star/-/tsparticles-shape-star-2.12.0.tgz",
-      "integrity": "sha512-4sfG/BBqm2qBnPLASl2L5aBfCx86cmZLXeh49Un+TIR1F5Qh4XUFsahgVOG0vkZQa+rOsZPEH04xY5feWmj90g==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-shape-text": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-shape-text/-/tsparticles-shape-text-2.12.0.tgz",
-      "integrity": "sha512-v2/FCA+hyTbDqp2ymFOe97h/NFb2eezECMrdirHWew3E3qlvj9S/xBibjbpZva2gnXcasBwxn0+LxKbgGdP0rA==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-slim": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-slim/-/tsparticles-slim-2.12.0.tgz",
-      "integrity": "sha512-27w9aGAAAPKHvP4LHzWFpyqu7wKyulayyaZ/L6Tuuejy4KP4BBEB4rY5GG91yvAPsLtr6rwWAn3yS+uxnBDpkA==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/matteobruni"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/tsparticles"
-        },
-        {
-          "type": "buymeacoffee",
-          "url": "https://www.buymeacoffee.com/matteobruni"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-basic": "^2.12.0",
-        "tsparticles-engine": "^2.12.0",
-        "tsparticles-interaction-external-attract": "^2.12.0",
-        "tsparticles-interaction-external-bounce": "^2.12.0",
-        "tsparticles-interaction-external-bubble": "^2.12.0",
-        "tsparticles-interaction-external-connect": "^2.12.0",
-        "tsparticles-interaction-external-grab": "^2.12.0",
-        "tsparticles-interaction-external-pause": "^2.12.0",
-        "tsparticles-interaction-external-push": "^2.12.0",
-        "tsparticles-interaction-external-remove": "^2.12.0",
-        "tsparticles-interaction-external-repulse": "^2.12.0",
-        "tsparticles-interaction-external-slow": "^2.12.0",
-        "tsparticles-interaction-particles-attract": "^2.12.0",
-        "tsparticles-interaction-particles-collisions": "^2.12.0",
-        "tsparticles-interaction-particles-links": "^2.12.0",
-        "tsparticles-move-base": "^2.12.0",
-        "tsparticles-move-parallax": "^2.12.0",
-        "tsparticles-particles.js": "^2.12.0",
-        "tsparticles-plugin-easing-quad": "^2.12.0",
-        "tsparticles-shape-circle": "^2.12.0",
-        "tsparticles-shape-image": "^2.12.0",
-        "tsparticles-shape-line": "^2.12.0",
-        "tsparticles-shape-polygon": "^2.12.0",
-        "tsparticles-shape-square": "^2.12.0",
-        "tsparticles-shape-star": "^2.12.0",
-        "tsparticles-shape-text": "^2.12.0",
-        "tsparticles-updater-color": "^2.12.0",
-        "tsparticles-updater-life": "^2.12.0",
-        "tsparticles-updater-opacity": "^2.12.0",
-        "tsparticles-updater-out-modes": "^2.12.0",
-        "tsparticles-updater-rotate": "^2.12.0",
-        "tsparticles-updater-size": "^2.12.0",
-        "tsparticles-updater-stroke-color": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-updater-color": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-updater-color/-/tsparticles-updater-color-2.12.0.tgz",
-      "integrity": "sha512-KcG3a8zd0f8CTiOrylXGChBrjhKcchvDJjx9sp5qpwQK61JlNojNCU35xoaSk2eEHeOvFjh0o3CXWUmYPUcBTQ==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-updater-destroy": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-updater-destroy/-/tsparticles-updater-destroy-2.12.0.tgz",
-      "integrity": "sha512-6NN3dJhxACvzbIGL4dADbYQSZJmdHfwjujj1uvnxdMbb2x8C/AZzGxiN33smo4jkrZ5VLEWZWCJPJ8aOKjQ2Sg==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-updater-life": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-updater-life/-/tsparticles-updater-life-2.12.0.tgz",
-      "integrity": "sha512-J7RWGHAZkowBHpcLpmjKsxwnZZJ94oGEL2w+wvW1/+ZLmAiFFF6UgU0rHMC5CbHJT4IPx9cbkYMEHsBkcRJ0Bw==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-updater-opacity": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-updater-opacity/-/tsparticles-updater-opacity-2.12.0.tgz",
-      "integrity": "sha512-YUjMsgHdaYi4HN89LLogboYcCi1o9VGo21upoqxq19yRy0hRCtx2NhH22iHF/i5WrX6jqshN0iuiiNefC53CsA==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-updater-out-modes": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-updater-out-modes/-/tsparticles-updater-out-modes-2.12.0.tgz",
-      "integrity": "sha512-owBp4Gk0JNlSrmp12XVEeBroDhLZU+Uq3szbWlHGSfcR88W4c/0bt0FiH5bHUqORIkw+m8O56hCjbqwj69kpOQ==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-updater-roll": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-updater-roll/-/tsparticles-updater-roll-2.12.0.tgz",
-      "integrity": "sha512-dxoxY5jP4C9x15BxlUv5/Q8OjUPBiE09ToXRyBxea9aEJ7/iMw6odvi1HuT0H1vTIfV7o1MYawjeCbMycvODKQ==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-updater-rotate": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-updater-rotate/-/tsparticles-updater-rotate-2.12.0.tgz",
-      "integrity": "sha512-waOFlGFmEZOzsQg4C4VSejNVXGf4dMf3fsnQrEROASGf1FCd8B6WcZau7JtXSTFw0OUGuk8UGz36ETWN72DkCw==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-updater-size": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-updater-size/-/tsparticles-updater-size-2.12.0.tgz",
-      "integrity": "sha512-B0yRdEDd/qZXCGDL/ussHfx5YJ9UhTqNvmS5X2rR2hiZhBAE2fmsXLeWkdtF2QusjPeEqFDxrkGiLOsh6poqRA==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-updater-stroke-color": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-updater-stroke-color/-/tsparticles-updater-stroke-color-2.12.0.tgz",
-      "integrity": "sha512-MPou1ZDxsuVq6SN1fbX+aI5yrs6FyP2iPCqqttpNbWyL+R6fik1rL0ab/x02B57liDXqGKYomIbBQVP3zUTW1A==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-updater-tilt": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-updater-tilt/-/tsparticles-updater-tilt-2.12.0.tgz",
-      "integrity": "sha512-HDEFLXazE+Zw+kkKKAiv0Fs9D9sRP61DoCR6jZ36ipea6OBgY7V1Tifz2TSR1zoQkk57ER9+EOQbkSQO+YIPGQ==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-updater-twinkle": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-updater-twinkle/-/tsparticles-updater-twinkle-2.12.0.tgz",
-      "integrity": "sha512-JhK/DO4kTx7IFwMBP2EQY9hBaVVvFnGBvX21SQWcjkymmN1hZ+NdcgUtR9jr4jUiiSNdSl7INaBuGloVjWvOgA==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-updater-wobble": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-updater-wobble/-/tsparticles-updater-wobble-2.12.0.tgz",
-      "integrity": "sha512-85FIRl95ipD3jfIsQdDzcUC5PRMWIrCYqBq69nIy9P8rsNzygn+JK2n+P1VQZowWsZvk0mYjqb9OVQB21Lhf6Q==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -9,15 +9,15 @@
     "lint": "eslint ."
   },
   "dependencies": {
+    "@tsparticles/engine": "^4.3.2",
+    "@tsparticles/react": "^4.3.2",
+    "@tsparticles/slim": "^4.3.2",
     "next": "16.2.10",
     "next-intl": "^4.13.2",
     "next-themes": "^0.4.6",
     "react": "19.2.7",
     "react-dom": "19.2.7",
-    "react-icons": "^4.6.0",
-    "react-particles": "^2.5.3",
-    "tsparticles": "^2.5.3",
-    "tsparticles-engine": "^2.12.0"
+    "react-icons": "^4.6.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.3.2",

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -1,7 +1,7 @@
 import { getTranslations } from 'next-intl/server';
 
 import Reveal from './Reveal';
-import SectionHeader from './SectionHeader';
+import Section from './Section';
 
 const technologies = [
   'TypeScript',
@@ -22,36 +22,29 @@ const About = async () => {
   const t = await getTranslations('about');
 
   return (
-    <div id='about'>
-      <div className='mx-auto flex w-full max-w-7xl gap-2 pt-24 pr-[3.625rem] pb-48 pl-2 text-xs lg:gap-7 lg:pr-[8.25rem] lg:text-sm'>
-        <div className='flex items-start gap-3.5 lg:gap-7'>
-          <div className='sticky top-20 flex'>
-            <SectionHeader>{t('title')}</SectionHeader>
-          </div>
-          <Reveal className='flex flex-col gap-4'>
-            <img
-              src='/images/me.jpg'
-              alt='Nathan S. Santos'
-              className='h-full w-full max-w-40 [filter:grayscale(100%)_contrast(1.25)]'
-            />
-            <div className='flex flex-col gap-4'>
-              <p>{t('description')}</p>
-              <p>{t('list-title')}:</p>
-              <ul className='flex max-h-28 max-w-[30rem] flex-col flex-wrap gap-1 gap-x-6 lg:max-h-[8.5rem]'>
-                {technologies.map((tech) => (
-                  <li
-                    key={tech}
-                    className="flex items-center gap-1 before:text-blue-500 before:content-['▹'] dark:before:text-teal-500"
-                  >
-                    {tech}
-                  </li>
-                ))}
-              </ul>
-            </div>
-          </Reveal>
+    <Section id='about' title={t('title')} className='text-xs lg:text-sm'>
+      <Reveal className='flex flex-col gap-4'>
+        <img
+          src='/images/me.jpg'
+          alt='Nathan S. Santos'
+          className='w-full max-w-40 [filter:grayscale(100%)_contrast(1.25)]'
+        />
+        <div className='flex flex-col gap-4'>
+          <p>{t('description')}</p>
+          <p>{t('list-title')}:</p>
+          <ul className='max-w-[30rem] columns-2 gap-x-6 sm:columns-3'>
+            {technologies.map((tech) => (
+              <li
+                key={tech}
+                className="mb-1 flex items-center gap-1 break-inside-avoid before:text-blue-500 before:content-['▹'] dark:before:text-teal-500"
+              >
+                {tech}
+              </li>
+            ))}
+          </ul>
         </div>
-      </div>
-    </div>
+      </Reveal>
+    </Section>
   );
 };
 

--- a/src/components/Background.tsx
+++ b/src/components/Background.tsx
@@ -1,65 +1,87 @@
 'use client';
 
+import type { Engine, ISourceOptions } from '@tsparticles/engine';
+import { Particles, ParticlesProvider, useParticlesProvider } from '@tsparticles/react';
+import { loadSlim } from '@tsparticles/slim';
 import { useTheme } from 'next-themes';
-import { useCallback } from 'react';
-import Particles from 'react-particles';
-import { loadFull } from 'tsparticles';
-import type { Engine } from 'tsparticles-engine';
+import { useMemo, useSyncExternalStore } from 'react';
 
-const Background = () => {
-  const { resolvedTheme } = useTheme();
-  const particleColor = resolvedTheme === 'light' ? '#333' : '#aaa';
+const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)';
 
-  const particlesInit = useCallback(async (engine: Engine) => {
-    await loadFull(engine);
-  }, []);
-
-  return (
-    <div className='absolute inset-0'>
-      <Particles
-        id='tsparticles'
-        init={particlesInit}
-        options={{
-          fpsLimit: 120,
-          interactivity: {
-            events: {
-              onHover: {
-                enable: true,
-                mode: 'grab',
-                parallax: { enable: true, smooth: 10, force: 15 },
-              },
-              resize: true,
-            },
-            modes: { grab: { distance: 300, line_linked: { opacity: 0.075 } } },
-          },
-          particles: {
-            color: { value: particleColor },
-            links: {
-              color: particleColor,
-              distance: 150,
-              enable: true,
-              opacity: 0.075,
-              width: 1,
-            },
-            collisions: { enable: true },
-            move: {
-              direction: 'none',
-              enable: true,
-              outModes: { default: 'bounce' },
-              random: false,
-              speed: 1,
-              straight: false,
-            },
-            number: { density: { enable: true, area: 800 }, value: 100 },
-            opacity: { value: 0.075 },
-            shape: { type: 'circle' },
-            size: { value: { min: 1, max: 2 } },
-          },
-          detectRetina: true,
-        }}
-      />
-    </div>
-  );
+const initEngine = async (engine: Engine) => {
+  await loadSlim(engine);
 };
+
+const subscribeReducedMotion = (onChange: () => void) => {
+  const query = window.matchMedia(REDUCED_MOTION_QUERY);
+
+  query.addEventListener('change', onChange);
+
+  return () => query.removeEventListener('change', onChange);
+};
+
+const usePrefersReducedMotion = () =>
+  useSyncExternalStore(
+    subscribeReducedMotion,
+    () => window.matchMedia(REDUCED_MOTION_QUERY).matches,
+    () => false,
+  );
+
+const ParticleField = () => {
+  const { loaded } = useParticlesProvider();
+  const { resolvedTheme } = useTheme();
+  const reducedMotion = usePrefersReducedMotion();
+
+  const color = resolvedTheme === 'light' ? '#333333' : '#aaaaaa';
+
+  const options = useMemo<ISourceOptions>(
+    () => ({
+      fullScreen: { enable: true, zIndex: -1 },
+      fpsLimit: 60,
+      detectRetina: true,
+      pauseOnBlur: true,
+      pauseOnOutsideViewport: true,
+      interactivity: {
+        events: {
+          onHover: {
+            enable: !reducedMotion,
+            mode: 'grab',
+            parallax: { enable: !reducedMotion, smooth: 10, force: 15 },
+          },
+          resize: { enable: true },
+        },
+        modes: { grab: { distance: 280, links: { opacity: 0.12 } } },
+      },
+      particles: {
+        color: { value: color },
+        links: { color, distance: 150, enable: true, opacity: 0.07, width: 1 },
+        collisions: { enable: !reducedMotion },
+        move: {
+          direction: 'none',
+          enable: !reducedMotion,
+          outModes: { default: 'bounce' },
+          random: false,
+          speed: 0.8,
+          straight: false,
+        },
+        number: { density: { enable: true, width: 1920, height: 1080 }, value: 80 },
+        opacity: { value: 0.07 },
+        shape: { type: 'circle' },
+        size: { value: { min: 1, max: 2 } },
+      },
+    }),
+    [color, reducedMotion],
+  );
+
+  if (!loaded) return null;
+
+  return <Particles id='tsparticles' options={options} />;
+};
+
+const Background = () => (
+  <ParticlesProvider init={initEngine}>
+    <ParticleField />
+  </ParticlesProvider>
+);
 
 export default Background;

--- a/src/components/ButtonLink.tsx
+++ b/src/components/ButtonLink.tsx
@@ -1,0 +1,12 @@
+import { AnchorHTMLAttributes } from 'react';
+
+type ButtonLinkProps = AnchorHTMLAttributes<HTMLAnchorElement>;
+
+const ButtonLink = ({ className = '', ...props }: ButtonLinkProps) => (
+  <a
+    className={`inline-flex rounded-md border border-blue-500 px-4 py-2 text-blue-500 transition hover:bg-blue-500/10 dark:border-teal-500 dark:text-teal-500 dark:hover:bg-teal-500/10 ${className}`}
+    {...props}
+  />
+);
+
+export default ButtonLink;

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -1,7 +1,23 @@
 import { getTranslations } from 'next-intl/server';
 import { RiGithubLine, RiInstagramLine, RiLinkedinLine, RiMailLine } from 'react-icons/ri';
 
+import ButtonLink from './ButtonLink';
 import Reveal from './Reveal';
+
+const socialLinks = [
+  { label: 'Github', href: 'https://github.com/nathanssantos/', Icon: RiGithubLine },
+  {
+    label: 'Instagram',
+    href: 'https://www.instagram.com/nathanssantosdev/',
+    Icon: RiInstagramLine,
+  },
+  {
+    label: 'LinkedIn',
+    href: 'https://www.linkedin.com/in/nathan-s-santos-4b2637163/',
+    Icon: RiLinkedinLine,
+  },
+  { label: 'E-mail', href: 'mailto:nathansilvasantos@gmail.com', Icon: RiMailLine },
+];
 
 const Contact = async () => {
   const t = await getTranslations('contact');
@@ -19,47 +35,25 @@ const Contact = async () => {
               <p className='text-center text-sm md:text-base'>{t('description-2')}</p>
             </div>
             <div className='flex items-center gap-4 text-blue-500 dark:text-teal-500'>
-              <a
-                aria-label='Github'
-                href='https://github.com/nathanssantos/'
-                target='_blank'
-                rel='noreferrer'
-                className='p-2 text-2xl'
-              >
-                <RiGithubLine />
-              </a>
-              <a
-                aria-label='Instagram'
-                href='https://www.instagram.com/nathanssantosdev/'
-                target='_blank'
-                rel='noreferrer'
-                className='p-2 text-2xl'
-              >
-                <RiInstagramLine />
-              </a>
-              <a
-                aria-label='LinkedIn'
-                href='https://www.linkedin.com/in/nathan-s-santos-4b2637163/'
-                target='_blank'
-                rel='noreferrer'
-                className='p-2 text-2xl'
-              >
-                <RiLinkedinLine />
-              </a>
-              <a
-                aria-label='E-mail'
-                href='mailto:nathansilvasantos@gmail.com'
-                className='p-2 text-2xl'
-              >
-                <RiMailLine />
-              </a>
+              {socialLinks.map(({ label, href, Icon }) => {
+                const isExternal = href.startsWith('http');
+
+                return (
+                  <a
+                    key={label}
+                    aria-label={label}
+                    href={href}
+                    className='p-2 text-2xl'
+                    {...(isExternal ? { target: '_blank', rel: 'noreferrer' } : {})}
+                  >
+                    <Icon />
+                  </a>
+                );
+              })}
             </div>
-            <a
-              href='mailto:nathansilvasantos@gmail.com'
-              className='rounded-md border border-blue-500 px-4 py-2 font-mono text-blue-500 transition hover:bg-blue-500/10 dark:border-teal-500 dark:text-teal-500 dark:hover:bg-teal-500/10'
-            >
+            <ButtonLink href='mailto:nathansilvasantos@gmail.com' className='font-mono'>
               {t('button-label')}
-            </a>
+            </ButtonLink>
           </div>
         </Reveal>
       </div>

--- a/src/components/Experience.tsx
+++ b/src/components/Experience.tsx
@@ -2,64 +2,55 @@ import { getTranslations } from 'next-intl/server';
 
 import { experience } from '../constants';
 import Reveal from './Reveal';
-import SectionHeader from './SectionHeader';
+import Section from './Section';
 
 const Experience = async () => {
   const t = await getTranslations('experience');
 
   return (
-    <div id='experience' className='font-mono'>
-      <div className='mx-auto flex w-full max-w-7xl pt-24 pr-[3.625rem] pb-48 pl-2 text-xs lg:pr-[8.25rem]'>
-        <div className='flex items-start gap-3.5 lg:gap-7'>
-          <div className='sticky top-20 flex'>
-            <SectionHeader>{t('title')}</SectionHeader>
-          </div>
-          <div className='flex flex-col gap-6'>
-            {experience.map((item, index) => (
-              <Reveal key={item.key} delay={index * 100}>
-                <a
-                  href={item.url}
-                  target='_blank'
-                  rel='noreferrer'
-                  className='group flex flex-col items-start gap-16 rounded-md bg-[rgba(230,230,230,0.75)] py-12 pr-8 pl-8 backdrop-blur-[5px] transition duration-200 hover:-translate-y-1 hover:shadow-xl md:flex-row md:py-8 md:pl-16 dark:bg-[rgba(42,42,42,0.75)]'
-                >
-                  <div className='w-28 min-w-28 self-center md:w-32 md:min-w-32'>
-                    <img
-                      alt={`${item.name} logo`}
-                      src={item.logo}
-                      className={`h-full w-full object-contain${
-                        item.logo.endsWith('.svg')
-                          ? ' dark:[filter:brightness(0)_invert(1)]'
-                          : ''
-                      }`}
-                    />
-                  </div>
-                  <div className='flex w-full flex-col'>
-                    <p className='mb-6 text-xl font-bold transition duration-200 group-hover:text-blue-500 dark:group-hover:text-teal-500'>
-                      {item.name}
-                    </p>
-                    <p className='mb-2'>{t(`list.${item.key}.description-1`)}</p>
-                    <p className='mb-6 transition duration-200 group-hover:text-blue-500 dark:group-hover:text-teal-500'>
-                      {t(`list.${item.key}.description-2`)}
-                    </p>
-                    <div className='flex flex-wrap gap-2'>
-                      {item.tags.map((tag) => (
-                        <span
-                          key={tag}
-                          className='rounded px-2 py-0.5 text-[#fff] bg-blue-500 dark:bg-teal-500 dark:text-[#222]'
-                        >
-                          {tag}
-                        </span>
-                      ))}
-                    </div>
-                  </div>
-                </a>
-              </Reveal>
-            ))}
-          </div>
-        </div>
+    <Section id='experience' title={t('title')} className='font-mono text-xs'>
+      <div className='flex flex-col gap-6'>
+        {experience.map((item, index) => (
+          <Reveal key={item.key} delay={index * 100}>
+            <a
+              href={item.url}
+              target='_blank'
+              rel='noreferrer'
+              className='group flex w-full flex-col items-start gap-16 rounded-md bg-[rgba(230,230,230,0.75)] py-12 pr-8 pl-8 backdrop-blur-[5px] transition duration-200 hover:-translate-y-1 hover:shadow-xl md:flex-row md:py-8 md:pl-16 dark:bg-[rgba(42,42,42,0.75)]'
+            >
+              <div className='w-28 min-w-28 self-center md:w-32 md:min-w-32'>
+                <img
+                  alt={`${item.name} logo`}
+                  src={item.logo}
+                  className={`h-full w-full object-contain${
+                    item.logo.endsWith('.svg') ? ' dark:[filter:brightness(0)_invert(1)]' : ''
+                  }`}
+                />
+              </div>
+              <div className='flex w-full flex-col'>
+                <p className='mb-6 text-xl font-bold transition duration-200 group-hover:text-blue-500 dark:group-hover:text-teal-500'>
+                  {item.name}
+                </p>
+                <p className='mb-2'>{t(`list.${item.key}.description-1`)}</p>
+                <p className='mb-6 transition duration-200 group-hover:text-blue-500 dark:group-hover:text-teal-500'>
+                  {t(`list.${item.key}.description-2`)}
+                </p>
+                <div className='flex flex-wrap gap-2'>
+                  {item.tags.map((tag) => (
+                    <span
+                      key={tag}
+                      className='rounded bg-blue-500 px-2 py-0.5 text-[#fff] dark:bg-teal-500 dark:text-[#222]'
+                    >
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            </a>
+          </Reveal>
+        ))}
       </div>
-    </div>
+    </Section>
   );
 };
 

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -1,8 +1,9 @@
 import { getTranslations } from 'next-intl/server';
 import { RiExternalLinkLine, RiGithubLine, RiStarLine } from 'react-icons/ri';
 
+import ButtonLink from './ButtonLink';
 import Reveal from './Reveal';
-import SectionHeader from './SectionHeader';
+import Section from './Section';
 
 type ProjectsProps = {
   projects: Repository[];
@@ -13,76 +14,66 @@ const Projects = async ({ projects }: ProjectsProps) => {
   const tCommon = await getTranslations('common');
 
   return (
-    <div id='projects' className='font-mono'>
-      <div className='mx-auto flex w-full max-w-7xl items-start pt-24 pr-[3.625rem] pb-48 pl-2 text-xs lg:pr-[8.25rem]'>
-        <div className='flex items-start gap-3.5 lg:gap-7'>
-          <div className='sticky top-20 flex pb-[4.25rem]'>
-            <SectionHeader>{t('title')}</SectionHeader>
-          </div>
-          <div className='flex flex-col'>
-            <div className='grid gap-6 lg:grid-cols-2 xl:grid-cols-3'>
-              {projects.map((item, index) => (
-                <Reveal key={item.id} delay={index * 100} className='h-full'>
-                  <div className='group flex h-full flex-col rounded-md bg-[rgba(230,230,230,0.75)] p-8 backdrop-blur-[5px] transition duration-200 hover:-translate-y-1 hover:shadow-xl dark:bg-[rgba(42,42,42,0.75)]'>
-                    <div className='mb-6 flex items-start justify-between gap-2 transition duration-200 group-hover:text-blue-500 dark:group-hover:text-teal-500'>
-                      <p className='text-lg font-bold'>{item.name}</p>
-                      {!!item.stargazers_count && (
-                        <div className='flex items-center gap-2 text-base'>
-                          <RiStarLine className='text-xl' />
-                          {item.stargazers_count}
-                        </div>
-                      )}
-                    </div>
-                    <div className='flex flex-1'>
-                      <p className='mb-8'>{t(`list.${item.name}.description`)}</p>
-                    </div>
-                    <div className='flex items-center justify-between gap-2'>
-                      <p className='text-sm font-bold transition duration-200 group-hover:text-blue-500 dark:group-hover:text-teal-500'>
-                        {item.language}
-                      </p>
-                      <div className='flex gap-2'>
-                        {!!item.homepage?.length && (
-                          <a
-                            href={item.homepage}
-                            target='_blank'
-                            rel='noreferrer'
-                            aria-label='Homepage Link'
-                            className='p-1 text-xl transition group-hover:text-blue-500 dark:group-hover:text-teal-500'
-                          >
-                            <RiExternalLinkLine />
-                          </a>
-                        )}
-                        <a
-                          href={`https://github.com/nathanssantos/${item.name}`}
-                          target='_blank'
-                          rel='noreferrer'
-                          aria-label='Github Link'
-                          className='p-1 text-xl transition group-hover:text-blue-500 dark:group-hover:text-teal-500'
-                        >
-                          <RiGithubLine />
-                        </a>
-                      </div>
-                    </div>
+    <Section id='projects' title={t('title')} className='font-mono text-xs'>
+      <div className='grid gap-6 lg:grid-cols-2 xl:grid-cols-3'>
+        {projects.map((item, index) => (
+          <Reveal key={item.id} delay={index * 100} className='h-full'>
+            <div className='group flex h-full flex-col rounded-md bg-[rgba(230,230,230,0.75)] p-8 backdrop-blur-[5px] transition duration-200 hover:-translate-y-1 hover:shadow-xl dark:bg-[rgba(42,42,42,0.75)]'>
+              <div className='mb-6 flex items-start justify-between gap-2 transition duration-200 group-hover:text-blue-500 dark:group-hover:text-teal-500'>
+                <p className='text-lg font-bold'>{item.name}</p>
+                {!!item.stargazers_count && (
+                  <div className='flex items-center gap-2 text-base'>
+                    <RiStarLine className='text-xl' />
+                    {item.stargazers_count}
                   </div>
-                </Reveal>
-              ))}
+                )}
+              </div>
+              <div className='flex flex-1'>
+                <p className='mb-8'>{t(`list.${item.name}.description`)}</p>
+              </div>
+              <div className='flex items-center justify-between gap-2'>
+                <p className='text-sm font-bold transition duration-200 group-hover:text-blue-500 dark:group-hover:text-teal-500'>
+                  {item.language}
+                </p>
+                <div className='flex gap-2'>
+                  {!!item.homepage?.length && (
+                    <a
+                      href={item.homepage}
+                      target='_blank'
+                      rel='noreferrer'
+                      aria-label='Homepage Link'
+                      className='p-1 text-xl transition group-hover:text-blue-500 dark:group-hover:text-teal-500'
+                    >
+                      <RiExternalLinkLine />
+                    </a>
+                  )}
+                  <a
+                    href={`https://github.com/nathanssantos/${item.name}`}
+                    target='_blank'
+                    rel='noreferrer'
+                    aria-label='Github Link'
+                    className='p-1 text-xl transition group-hover:text-blue-500 dark:group-hover:text-teal-500'
+                  >
+                    <RiGithubLine />
+                  </a>
+                </div>
+              </div>
             </div>
-            <div className='mt-8 self-center'>
-              <Reveal>
-                <a
-                  href='https://github.com/nathanssantos?tab=repositories'
-                  target='_blank'
-                  rel='noreferrer'
-                  className='rounded-md border border-blue-500 px-4 py-2 text-blue-500 transition hover:bg-blue-500/10 dark:border-teal-500 dark:text-teal-500 dark:hover:bg-teal-500/10'
-                >
-                  {tCommon('view-more')}
-                </a>
-              </Reveal>
-            </div>
-          </div>
-        </div>
+          </Reveal>
+        ))}
       </div>
-    </div>
+      <div className='mt-8 flex justify-center'>
+        <Reveal>
+          <ButtonLink
+            href='https://github.com/nathanssantos?tab=repositories'
+            target='_blank'
+            rel='noreferrer'
+          >
+            {tCommon('view-more')}
+          </ButtonLink>
+        </Reveal>
+      </div>
+    </Section>
   );
 };
 

--- a/src/components/Section.tsx
+++ b/src/components/Section.tsx
@@ -1,0 +1,25 @@
+import { ReactNode } from 'react';
+
+import SectionHeader from './SectionHeader';
+
+type SectionProps = {
+  id: string;
+  title: string;
+  children: ReactNode;
+  className?: string;
+};
+
+const Section = ({ id, title, children, className = '' }: SectionProps) => (
+  <section id={id}>
+    <div className='mx-auto flex w-full max-w-7xl pt-24 pr-[3.625rem] pb-48 pl-2 lg:pr-[8.25rem]'>
+      <div className='flex w-full items-start gap-3.5 lg:gap-7'>
+        <div className='sticky top-20 flex'>
+          <SectionHeader>{title}</SectionHeader>
+        </div>
+        <div className={`min-w-0 flex-1 ${className}`}>{children}</div>
+      </div>
+    </div>
+  </section>
+);
+
+export default Section;


### PR DESCRIPTION
## Contexto

Ao validar a migração no browser, apareceram dois problemas de layout que o build de prod **não** tinha, mais a atualização da lib de partículas (a última desatualizada de verdade). Comparei tudo com prod (`nathanssantos.vercel.app`) medindo a geometria dos containers.

## 1. Layout — conteúdo voltou a preencher e centralizar

O conteúdo das seções estava **encolhendo para a largura natural e grudando na esquerda**, deixando um vazio enorme à direita (não centralizado). Em prod o container é idêntico, mas o bloco interno tem **largura total**.

**Fix:** a coluna de conteúdo do `Section` agora é `flex-1 min-w-0`. Medição a 1920px:

| | descrição (left→right) | bate com prod? |
|---|---|---|
| prod | 452 → 1468 (w 1016) | — |
| **agora** | 447 → 1468 (w 1021) | ✅ |

About, Experience (cards) e Projects (grid) passam a preencher a coluna, centralizados simetricamente como prod.

## 2. Responsividade mobile — fim do scroll horizontal

A lista de tecnologias do About era um `flex-wrap` de altura fixa que **vazava o viewport** em telas estreitas (`scrollWidth 437 > 375`). Virou **multi-column responsivo** (`columns-2 sm:columns-3`).

- Antes (375px): `hasHorizontalOverflow: true` (437px)
- Agora (375px): `hasHorizontalOverflow: false` (375px) ✅

## 3. Partículas — `react-particles`/`tsparticles` v2 → `@tsparticles/react` v4

`react-particles` foi descontinuado. Migração para o pacote atual + melhorias (mantendo as cores discretas para **não poluir o conteúdo por cima**, como pedido):

- canvas `fullScreen` fixado em **`zIndex: -1`** → sempre atrás do conteúdo (o default v3+ é `zIndex: 0`, que sobreporia)
- **60fps** (era 120) + `pauseOnBlur` + `pauseOnOutsideViewport` → menos CPU
- respeita **`prefers-reduced-motion`** (`useSyncExternalStore`, SSR-safe)
- cores theme-aware, opacidade 0.07 (discreto)

## 4. DRY — componentes compartilhados

- **`Section`** — a "casca" de seção (container centralizado + header vertical sticky + coluna de conteúdo) que About/Experience/Projects duplicavam; o fix de preenchimento mora aqui, então vale para as três de uma vez
- **`ButtonLink`** — o botão-outline duplicado idêntico em Contact e Projects
- Links sociais do Contact → `map` data-driven

## Verificação

- `npm run build` ✅ · `eslint .` ✅ (só os 2 warnings de `<img>`, já previstos p/ o PR de `next/image`)
- Validado no browser em **375 / 1280 / 1440 / 1920**, comparado com prod: centralização, preenchimento e zero overflow horizontal

🤖 Generated with [Claude Code](https://claude.com/claude-code)