### PR TITLE
Migrate <img> to next/image (fix logo distortion + optimize)

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -5,6 +5,11 @@ const withNextIntl = createNextIntlPlugin('./src/i18n/request.ts');
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  images: {
+    dangerouslyAllowSVG: true,
+    contentDispositionType: 'attachment',
+    contentSecurityPolicy: "default-src 'self'; script-src 'none'; sandbox;",
+  },
 };
 
 export default withNextIntl(nextConfig);

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -1,3 +1,4 @@
+import Image from 'next/image';
 import { getTranslations } from 'next-intl/server';
 
 import Reveal from './Reveal';
@@ -24,10 +25,12 @@ const About = async () => {
   return (
     <Section id='about' title={t('title')} className='text-xs lg:text-sm'>
       <Reveal className='flex flex-col gap-4'>
-        <img
+        <Image
           src='/images/me.jpg'
           alt='Nathan S. Santos'
-          className='w-full max-w-40 [filter:grayscale(100%)_contrast(1.25)]'
+          width={637}
+          height={637}
+          className='h-auto w-full max-w-40 [filter:grayscale(100%)_contrast(1.25)]'
         />
         <div className='flex flex-col gap-4'>
           <p>{t('description')}</p>

--- a/src/components/Experience.tsx
+++ b/src/components/Experience.tsx
@@ -1,3 +1,4 @@
+import Image from 'next/image';
 import { getTranslations } from 'next-intl/server';
 
 import { experience } from '../constants';
@@ -18,12 +19,14 @@ const Experience = async () => {
               rel='noreferrer'
               className='group flex w-full flex-col items-start gap-16 rounded-md bg-[rgba(230,230,230,0.75)] py-12 pr-8 pl-8 backdrop-blur-[5px] transition duration-200 hover:-translate-y-1 hover:shadow-xl md:flex-row md:py-8 md:pl-16 dark:bg-[rgba(42,42,42,0.75)]'
             >
-              <div className='w-28 min-w-28 self-center md:w-32 md:min-w-32'>
-                <img
+              <div className='relative h-16 w-28 min-w-28 self-center md:h-20 md:w-32 md:min-w-32'>
+                <Image
                   alt={`${item.name} logo`}
                   src={item.logo}
-                  className={`h-full w-full object-contain${
-                    item.logo.endsWith('.svg') ? ' dark:[filter:brightness(0)_invert(1)]' : ''
+                  fill
+                  sizes='128px'
+                  className={`object-contain ${
+                    item.logo.endsWith('.svg') ? 'dark:[filter:brightness(0)_invert(1)]' : ''
                   }`}
                 />
               </div>


### PR DESCRIPTION
## O quê

Troca os `<img>` por `next/image` (foto do About + logos do Experience) — otimização automática + os 2 últimos warnings de lint zerados.

## Bug pego no caminho: logos esticados

Ao usar `next/image` com `fill`, **todos os logos apareciam esticados** para a proporção da caixa (ex.: TAG 3.90 → 1.60). Causa-raiz:

- o Tailwind v4 **não gerava** a regra `.object-contain` porque a classe estava colada numa interpolação: `` `object-contain${...}` `` — o scanner não reconhecia o token
- sem a regra, o `fill` do `next/image` (que posiciona absoluto 100%×100%) caía no default `object-fit: fill` → **estica**

**Fix:** separar a classe (`object-contain ${...}`) para o Tailwind detectar. Verificado no browser: `object-fit` agora é `contain` nos 8 logos, aspecto natural preservado, zero distorção.

## Detalhes

| Imagem | Abordagem |
|---|---|
| Foto (me.jpg, 637×637) | `width/height` intrínsecos + `h-auto w-full max-w-40` (quadrada, sem distorção) |
| Logos (svg/png/webp) | `fill` em caixa `object-contain` de tamanho fixo (`relative h-16 w-28` / `md:h-20 w-32`), `sizes=128px` → só busca a variante pequena otimizada (nada de request 3840px p/ logo minúsculo) |

- `images.dangerouslyAllowSVG` habilitado (assets próprios, confiáveis) com hardening de CSP (`script-src 'none'; sandbox`) para o SVG do Clint passar pelo otimizador
- Endpoints `/_next/image` conferidos: svg/png/jpg → **200**

## Verificação

- `npm run build` ✅ · `eslint .` ✅ **100% limpo** (fim dos `no-img-element`)
- Logos revalidados no browser (1440px): aspecto natural, invertidos p/ branco no dark, alinhados na caixa uniforme

🤖 Generated with [Claude Code](https://claude.com/claude-code)