### PR TITLE
chore(deps): react-icons v4 → v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "next-themes": "^0.4.6",
         "react": "19.2.7",
         "react-dom": "19.2.7",
-        "react-icons": "^4.6.0"
+        "react-icons": "^5.7.0"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.3.2",
@@ -7476,9 +7476,9 @@
       }
     },
     "node_modules/react-icons": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.12.0.tgz",
-      "integrity": "sha512-IBaDuHiShdZqmfc/TwHu6+d6k2ltNCf3AszxNmjJc1KUfXdEeRJOKyNvLmAHaarhzGmTSVygNdyu8/opXv2gaw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.7.0.tgz",
+      "integrity": "sha512-LBLy340Rzqy6+/yVhZKT3B/QpP1BZaesGqasf09HPOBzRarcDIFH0WwXlXQfE7q7ipxK4MSiC5DIBWURCny6fw==",
       "license": "MIT",
       "peerDependencies": {
         "react": "*"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "next-themes": "^0.4.6",
     "react": "19.2.7",
     "react-dom": "19.2.7",
-    "react-icons": "^4.6.0"
+    "react-icons": "^5.7.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.3.2",


### PR DESCRIPTION
Última dependência de runtime desatualizada.

- Todos os 11 ícones em uso (`Ri*`) verificados como existentes na v5
- `npm run build` ✅ · `eslint .` ✅

Depois deste, as únicas "desatualizadas" restantes são ESLint 10 e TypeScript 7, **pinadas de propósito** (quebram o ecossistema do Next 16 — documentado nos PRs anteriores).

🤖 Generated with [Claude Code](https://claude.com/claude-code)