### PR TITLE
feat(seo): localized metadata + full link-preview (OG image, sitemap, robots)

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,10 +1,11 @@
 import type { Metadata } from 'next';
 import { hasLocale, NextIntlClientProvider } from 'next-intl';
-import { setRequestLocale } from 'next-intl/server';
+import { getTranslations, setRequestLocale } from 'next-intl/server';
 import { Inter, Roboto_Mono } from 'next/font/google';
 import { notFound } from 'next/navigation';
 import { ReactNode } from 'react';
 
+import site from '../../constants/site';
 import { routing } from '../../i18n/routing';
 import Providers from './providers';
 import '../globals.css';
@@ -16,27 +17,42 @@ const robotoMono = Roboto_Mono({
   display: 'swap',
 });
 
-const description =
-  'Software Engineer with 7+ years building web, mobile and desktop products with React, Node.js, TypeScript and AI. Portfolio of Nathan S. Santos — projects, open source and experience.';
+const ogLocales: Record<string, string> = { en: 'en_US', pt: 'pt_BR' };
 
-export const metadata: Metadata = {
-  metadataBase: new URL('https://nathanssantos.vercel.app'),
-  title: 'Nathan S. Santos',
-  description,
-  authors: [{ name: 'Nathan S. Santos' }],
-  openGraph: {
-    type: 'website',
-    title: 'Nathan S. Santos',
+type LayoutParams = { params: Promise<{ locale: string }> };
+
+export const generateMetadata = async ({ params }: LayoutParams): Promise<Metadata> => {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: 'metadata' });
+  const title = t('title');
+  const description = t('description');
+
+  return {
+    metadataBase: new URL(site.url),
+    title,
     description,
-    url: 'https://nathanssantos.vercel.app/',
-    images: ['/images/me.jpg'],
-  },
-  twitter: {
-    card: 'summary',
-    title: 'Nathan S. Santos',
-    description,
-    images: ['/images/me.jpg'],
-  },
+    authors: [{ name: site.name }],
+    alternates: {
+      canonical: `/${locale}`,
+      languages: { en: '/en', pt: '/pt' },
+    },
+    openGraph: {
+      type: 'website',
+      siteName: site.name,
+      title,
+      description,
+      url: `/${locale}`,
+      locale: ogLocales[locale],
+      alternateLocale: routing.locales
+        .filter((item) => item !== locale)
+        .map((item) => ogLocales[item]),
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+    },
+  };
 };
 
 export const generateStaticParams = () => routing.locales.map((locale) => ({ locale }));

--- a/src/app/[locale]/opengraph-image.tsx
+++ b/src/app/[locale]/opengraph-image.tsx
@@ -1,0 +1,57 @@
+import { ImageResponse } from 'next/og';
+import { getTranslations } from 'next-intl/server';
+
+import site from '../../constants/site';
+import { routing } from '../../i18n/routing';
+
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+export const alt = site.name;
+
+export const generateStaticParams = () => routing.locales.map((locale) => ({ locale }));
+
+type OgImageProps = { params: Promise<{ locale: string }> };
+
+const OpengraphImage = async ({ params }: OgImageProps) => {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: 'metadata' });
+
+  return new ImageResponse(
+    <div
+      style={{
+        height: '100%',
+        width: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        padding: '90px',
+        backgroundColor: '#222222',
+        fontFamily: 'monospace',
+      }}
+    >
+      <div style={{ display: 'flex', fontSize: 40, color: '#64ffda' }}>
+        {site.url.replace('https://', '')}
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          marginTop: 24,
+          fontSize: 96,
+          fontWeight: 800,
+          color: 'transparent',
+          backgroundImage: 'linear-gradient(120deg, #64ffda 20%, #5374fa 70%)',
+          backgroundClip: 'text',
+          WebkitBackgroundClip: 'text',
+        }}
+      >
+        {site.name}
+      </div>
+      <div style={{ display: 'flex', marginTop: 16, fontSize: 44, color: '#f0f0f0' }}>
+        {t('title').split('—')[1]?.trim() ?? t('title')}
+      </div>
+    </div>,
+    size,
+  );
+};
+
+export default OpengraphImage;

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,11 @@
+import type { MetadataRoute } from 'next';
+
+import site from '../constants/site';
+
+const robots = (): MetadataRoute.Robots => ({
+  rules: { userAgent: '*', allow: '/' },
+  sitemap: `${site.url}/sitemap.xml`,
+  host: site.url,
+});
+
+export default robots;

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,20 @@
+import type { MetadataRoute } from 'next';
+
+import site from '../constants/site';
+import { routing } from '../i18n/routing';
+
+const sitemap = (): MetadataRoute.Sitemap => {
+  const languages = Object.fromEntries(
+    routing.locales.map((locale) => [locale, `${site.url}/${locale}`]),
+  );
+
+  return routing.locales.map((locale) => ({
+    url: `${site.url}/${locale}`,
+    lastModified: new Date(),
+    changeFrequency: 'monthly',
+    priority: locale === routing.defaultLocale ? 1 : 0.8,
+    alternates: { languages },
+  }));
+};
+
+export default sitemap;

--- a/src/constants/site.ts
+++ b/src/constants/site.ts
@@ -1,0 +1,17 @@
+const site = {
+  name: 'Nathan S. Santos',
+  url: 'https://nathanssantos.vercel.app',
+  githubUsername: 'nathanssantos',
+  email: 'nathansilvasantos@gmail.com',
+  social: {
+    github: 'https://github.com/nathanssantos/',
+    instagram: 'https://www.instagram.com/nathanssantosdev/',
+    linkedin: 'https://www.linkedin.com/in/nathan-s-santos-4b2637163/',
+  },
+  resume: {
+    en: '/Resume-Nathan_Silva_Santos.pdf',
+    pt: '/CV-Nathan_Silva_Santos-PT.pdf',
+  },
+} as const;
+
+export default site;

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -70,6 +70,10 @@
     "description": "I’m a fullstack software engineer with 7+ years of experience building high-performance web and desktop applications.",
     "description-2": "Specialized in React, TypeScript, and Node.js, with a focus on design systems and AI-assisted development — currently open to new opportunities."
   },
+  "metadata": {
+    "title": "Nathan S. Santos — Software Engineer",
+    "description": "Software Engineer with 7+ years building web, mobile and desktop products with React, Node.js, TypeScript and AI. Portfolio of Nathan S. Santos — projects, open source and experience."
+  },
   "notFound": {
     "h1": "The page you are looking for is not available or doesn't belong to this website!",
     "title": "Page not found"

--- a/src/messages/pt.json
+++ b/src/messages/pt.json
@@ -70,6 +70,10 @@
     "description": "Sou um desenvolvedor de software fullstack com mais de 7 anos de experiência construindo aplicações web e desktop de alta performance.",
     "description-2": "Especializado em React, TypeScript e Node.js, com foco em design systems e desenvolvimento potencializado por IA — atualmente aberto a novas oportunidades."
   },
+  "metadata": {
+    "title": "Nathan S. Santos — Engenheiro de Software",
+    "description": "Engenheiro de Software com mais de 7 anos construindo produtos web, mobile e desktop com React, Node.js, TypeScript e IA. Portfólio de Nathan S. Santos — projetos, open source e experiência."
+  },
   "notFound": {
     "h1": "A página que você procura não foi encontrada ou não pertence a este website!",
     "title": "Página não encontrada."


### PR DESCRIPTION
## Contexto

Você pediu pra garantir o **preview completo do link** ao colar em qualquer lugar. As tags OG existiam, mas era o card **pequeno** (`summary`, foto quadrada 637×637), sem dimensões de imagem, e **os dois idiomas serviam metadata em inglês**, sem canonical/hreflang.

## O que entrou

**Metadata localizada** (`generateMetadata` por locale)
- `title` + `description` traduzidos (novo namespace `metadata` em en/pt)
- `alternates.canonical` + `alternates.languages` (**hreflang** en/pt)

**Open Graph completo**
- `og:site_name`, `og:url` por locale, `og:locale` (en_US / pt_BR) + `og:locale:alternate`
- **`opengraph-image` dedicada 1200×630** via `next/og` — dark, nome em gradiente, tagline localizada → traz `og:image:width/height/alt` (**o LinkedIn precisa das dimensões**) e sobe o Twitter pra **`summary_large_image`** (card grande)

**Indexação**
- `sitemap.ts` (os 2 locales com hreflang) + `robots.ts` (→ sitemap)

**Centralização**
- `constants/site.ts` como fonte única de URL/nome/handles, reusado por layout, sitemap, robots e a OG image (evita hardcode do domínio em 4 lugares)

## Preview gerado

![og](https://nathanssantos.vercel.app/en/opengraph-image)

_(a imagem acima só aparece após o deploy; localmente confirmei o PNG 1200×630)_

## Verificação (runtime)

- `<head>` de `/en` e `/pt`: canonical, hreflang, OG completo com `og:image:width/height/alt`, twitter `summary_large_image`, tudo **localizado** (PT serve PT)
- `/sitemap.xml` e `/robots.txt` corretos
- OG endpoint → **200, image/png, 1200×630**
- `build` ✅ · `eslint` ✅

## Nota

Coloquei um sufixo de cargo no `<title>` (`— Software Engineer` / `— Engenheiro de Software`) por SEO (title tag é o fator on-page nº1). Se preferir só "Nathan S. Santos", é trivial reverter — é só me falar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)