### PR TITLE
refactor: centralize site content constants + tidy types

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -19,9 +19,7 @@ const robotoMono = Roboto_Mono({
 
 const ogLocales: Record<string, string> = { en: 'en_US', pt: 'pt_BR' };
 
-type LayoutParams = { params: Promise<{ locale: string }> };
-
-export const generateMetadata = async ({ params }: LayoutParams): Promise<Metadata> => {
+export const generateMetadata = async ({ params }: LocalePageProps): Promise<Metadata> => {
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: 'metadata' });
   const title = t('title');
@@ -57,9 +55,8 @@ export const generateMetadata = async ({ params }: LayoutParams): Promise<Metada
 
 export const generateStaticParams = () => routing.locales.map((locale) => ({ locale }));
 
-type LocaleLayoutProps = {
+type LocaleLayoutProps = LocalePageProps & {
   children: ReactNode;
-  params: Promise<{ locale: string }>;
 };
 
 const LocaleLayout = async ({ children, params }: LocaleLayoutProps) => {

--- a/src/app/[locale]/opengraph-image.tsx
+++ b/src/app/[locale]/opengraph-image.tsx
@@ -10,9 +10,7 @@ export const alt = site.name;
 
 export const generateStaticParams = () => routing.locales.map((locale) => ({ locale }));
 
-type OgImageProps = { params: Promise<{ locale: string }> };
-
-const OpengraphImage = async ({ params }: OgImageProps) => {
+const OpengraphImage = async ({ params }: LocalePageProps) => {
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: 'metadata' });
 

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -8,20 +8,12 @@ import Footer from '../../components/Footer';
 import Header from '../../components/Header';
 import Hero from '../../components/Hero';
 import Projects from '../../components/Projects';
-
-const favoriteRepositories = [
-  'evolution-graph',
-  'react-boilerplate',
-  'podjs',
-  'clockify-teams',
-  'pure-components',
-  'marketmind',
-];
+import { favoriteRepositories, site } from '../../constants';
 
 const getRepositories = async (): Promise<Repository[]> => {
   try {
     const response = await fetch(
-      'https://api.github.com/users/nathanssantos/repos?per_page=100',
+      `https://api.github.com/users/${site.githubUsername}/repos?per_page=100`,
       {
         headers: { Accept: 'application/vnd.github+json' },
         next: { revalidate: 3600 },
@@ -40,11 +32,7 @@ const getRepositories = async (): Promise<Repository[]> => {
   }
 };
 
-type HomePageProps = {
-  params: Promise<{ locale: string }>;
-};
-
-const HomePage = async ({ params }: HomePageProps) => {
+const HomePage = async ({ params }: LocalePageProps) => {
   const { locale } = await params;
   setRequestLocale(locale);
 

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -1,23 +1,9 @@
 import Image from 'next/image';
 import { getTranslations } from 'next-intl/server';
 
+import { technologies } from '../constants';
 import Reveal from './Reveal';
 import Section from './Section';
-
-const technologies = [
-  'TypeScript',
-  'React / React Native',
-  'Next.js',
-  'Electron',
-  'Node.js',
-  'Fastify / tRPC',
-  'PostgreSQL',
-  'Canvas API',
-  'Vitest / Cypress',
-  'Chakra UI',
-  'Zustand / MobX',
-  'pnpm Monorepo',
-];
 
 const About = async () => {
   const t = await getTranslations('about');

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -1,22 +1,17 @@
 import { getTranslations } from 'next-intl/server';
 import { RiGithubLine, RiInstagramLine, RiLinkedinLine, RiMailLine } from 'react-icons/ri';
 
+import { site } from '../constants';
 import ButtonLink from './ButtonLink';
 import Reveal from './Reveal';
 
+const mailHref = `mailto:${site.email}`;
+
 const socialLinks = [
-  { label: 'Github', href: 'https://github.com/nathanssantos/', Icon: RiGithubLine },
-  {
-    label: 'Instagram',
-    href: 'https://www.instagram.com/nathanssantosdev/',
-    Icon: RiInstagramLine,
-  },
-  {
-    label: 'LinkedIn',
-    href: 'https://www.linkedin.com/in/nathan-s-santos-4b2637163/',
-    Icon: RiLinkedinLine,
-  },
-  { label: 'E-mail', href: 'mailto:nathansilvasantos@gmail.com', Icon: RiMailLine },
+  { label: 'Github', href: site.social.github, Icon: RiGithubLine },
+  { label: 'Instagram', href: site.social.instagram, Icon: RiInstagramLine },
+  { label: 'LinkedIn', href: site.social.linkedin, Icon: RiLinkedinLine },
+  { label: 'E-mail', href: mailHref, Icon: RiMailLine },
 ];
 
 const Contact = async () => {
@@ -51,7 +46,7 @@ const Contact = async () => {
                 );
               })}
             </div>
-            <ButtonLink href='mailto:nathansilvasantos@gmail.com' className='font-mono'>
+            <ButtonLink href={mailHref} className='font-mono'>
               {t('button-label')}
             </ButtonLink>
           </div>

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -2,6 +2,8 @@
 
 import { useLocale, useTranslations } from 'next-intl';
 
+import { site } from '../constants';
+
 type MenuProps = {
   vertical?: boolean;
 };
@@ -13,8 +15,7 @@ const Menu = ({ vertical = false }: MenuProps) => {
   const t = useTranslations('header');
   const locale = useLocale();
 
-  const resumeHref =
-    locale === 'pt' ? '/CV-Nathan_Silva_Santos-PT.pdf' : '/Resume-Nathan_Silva_Santos.pdf';
+  const resumeHref = locale === 'pt' ? site.resume.pt : site.resume.en;
 
   const items = [
     { id: 'about', label: t('about') },

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -1,6 +1,7 @@
 import { getTranslations } from 'next-intl/server';
 import { RiExternalLinkLine, RiGithubLine, RiStarLine } from 'react-icons/ri';
 
+import { site } from '../constants';
 import ButtonLink from './ButtonLink';
 import Reveal from './Reveal';
 import Section from './Section';
@@ -48,7 +49,7 @@ const Projects = async ({ projects }: ProjectsProps) => {
                     </a>
                   )}
                   <a
-                    href={`https://github.com/nathanssantos/${item.name}`}
+                    href={`https://github.com/${site.githubUsername}/${item.name}`}
                     target='_blank'
                     rel='noreferrer'
                     aria-label='Github Link'
@@ -65,7 +66,7 @@ const Projects = async ({ projects }: ProjectsProps) => {
       <div className='mt-8 flex justify-center'>
         <Reveal>
           <ButtonLink
-            href='https://github.com/nathanssantos?tab=repositories'
+            href={`https://github.com/${site.githubUsername}?tab=repositories`}
             target='_blank'
             rel='noreferrer'
           >

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,3 +1,6 @@
 import experience from './experience';
+import favoriteRepositories from './repositories';
+import site from './site';
+import technologies from './technologies';
 
-export { experience };
+export { experience, favoriteRepositories, site, technologies };

--- a/src/constants/repositories.ts
+++ b/src/constants/repositories.ts
@@ -1,0 +1,10 @@
+const favoriteRepositories = [
+  'evolution-graph',
+  'react-boilerplate',
+  'podjs',
+  'clockify-teams',
+  'pure-components',
+  'marketmind',
+];
+
+export default favoriteRepositories;

--- a/src/constants/technologies.ts
+++ b/src/constants/technologies.ts
@@ -1,0 +1,16 @@
+const technologies = [
+  'TypeScript',
+  'React / React Native',
+  'Next.js',
+  'Electron',
+  'Node.js',
+  'Fastify / tRPC',
+  'PostgreSQL',
+  'Canvas API',
+  'Vitest / Cypress',
+  'Chakra UI',
+  'Zustand / MobX',
+  'pnpm Monorepo',
+];
+
+export default technologies;

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,1 +1,7 @@
-type FetchStatus = 'idle' | 'fetching' | 'error' | 'success' | 'empty' | 'timeout';
+type LocaleParams = {
+  locale: string;
+};
+
+type LocalePageProps = {
+  params: Promise<LocaleParams>;
+};


### PR DESCRIPTION
## Motivação

Você pediu (1) uma forma boa de **centralizar as constantes de conteúdo** espalhadas pelos componentes, pra facilitar atualizar textos/conteúdo, e (2) uma **revisão dos tipos** (duplicados / o que poderia ser global).

## Constantes

Tudo que é conteúdo/URL agora mora em `src/constants/`:

- **`site.ts`** — fonte única: `name`, `url`, `githubUsername`, `email`, `social` (github/instagram/linkedin), `resume` (en/pt)
- **`technologies.ts`** e **`repositories.ts`** — saíram de dentro de `About`/`page`
- Componentes passam a ler dali:
  - `Contact` → `site.social` + `site.email` (links e CTA)
  - `Menu` → `site.resume[locale]`
  - `Projects` → `site.githubUsername` (links de repo + "view more")
  - `page` → `site.githubUsername` na chamada da API do GitHub
- **Zero handle/URL de conteúdo hardcoded** sobrando nos componentes

Atualizar um texto/link agora é num lugar só.

## Tipos

- **Removido `FetchStatus`** — estava definido e nunca usado (morto)
- **Novo `LocaleParams` / `LocalePageProps` globais** — o shape `params: Promise<{ locale }>` estava repetido em `layout`, `page` e `opengraph-image`; agora é um tipo só
- `Repository` / `Job` seguem como globais ambientes (são domain models usados em server e client)

## Verificação

Sem mudança de comportamento — conferi no HTML renderizado que resume (por locale), socials e links de projeto saem com as URLs corretas. `build` ✅ · `eslint` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)