### PR TITLE
feat(a11y): semantic headings, focus + pointer states, localized 404/error

### DIFF
--- a/src/app/[locale]/[...rest]/page.tsx
+++ b/src/app/[locale]/[...rest]/page.tsx
@@ -1,0 +1,7 @@
+import { notFound } from 'next/navigation';
+
+const CatchAllPage = () => {
+  notFound();
+};
+
+export default CatchAllPage;

--- a/src/app/[locale]/error.tsx
+++ b/src/app/[locale]/error.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+type ErrorProps = {
+  reset: () => void;
+};
+
+const Error = ({ reset }: ErrorProps) => {
+  const t = useTranslations('error');
+
+  return (
+    <main className='flex min-h-[80vh] flex-col items-center justify-center gap-6 px-6 text-center'>
+      <h1 className='m-0 bg-clip-text font-mono text-3xl font-black text-transparent [background-image:linear-gradient(120deg,#5374fa_40%,#64ffda_80%)] md:text-4xl dark:[background-image:linear-gradient(120deg,#64ffda_30%,#5374fa_60%)]'>
+        {t('title')}
+      </h1>
+      <p className='max-w-xl text-sm md:text-base'>{t('description')}</p>
+      <button
+        type='button'
+        onClick={reset}
+        className='inline-flex rounded-md border border-blue-500 px-4 py-2 font-mono text-sm text-blue-500 transition hover:bg-blue-500/10 dark:border-teal-500 dark:text-teal-500 dark:hover:bg-teal-500/10'
+      >
+        {t('retry')}
+      </button>
+    </main>
+  );
+};
+
+export default Error;

--- a/src/app/[locale]/not-found.tsx
+++ b/src/app/[locale]/not-found.tsx
@@ -1,0 +1,24 @@
+import { getTranslations } from 'next-intl/server';
+
+import { Link } from '../../i18n/navigation';
+
+const NotFound = async () => {
+  const t = await getTranslations('notFound');
+
+  return (
+    <main className='flex min-h-[80vh] flex-col items-center justify-center gap-6 px-6 text-center'>
+      <p className='bg-clip-text font-mono text-7xl font-black text-transparent [background-image:linear-gradient(120deg,#5374fa_40%,#64ffda_80%)] md:text-8xl dark:[background-image:linear-gradient(120deg,#64ffda_30%,#5374fa_60%)]'>
+        404
+      </p>
+      <h1 className='m-0 max-w-xl text-base font-medium md:text-lg'>{t('h1')}</h1>
+      <Link
+        href='/'
+        className='inline-flex rounded-md border border-blue-500 px-4 py-2 font-mono text-sm text-blue-500 transition hover:bg-blue-500/10 dark:border-teal-500 dark:text-teal-500 dark:hover:bg-teal-500/10'
+      >
+        {t('back')}
+      </Link>
+    </main>
+  );
+};
+
+export default NotFound;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -23,4 +23,20 @@
   .dark body {
     background-color: #222222;
   }
+
+  button:not(:disabled),
+  [role='button']:not([aria-disabled='true']),
+  summary {
+    cursor: pointer;
+  }
+
+  :focus-visible {
+    outline: 2px solid var(--color-blue-500);
+    outline-offset: 3px;
+    border-radius: 2px;
+  }
+
+  .dark :focus-visible {
+    outline-color: var(--color-teal-500);
+  }
 }

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -21,9 +21,9 @@ const Contact = async () => {
     <div id='contact'>
       <div className='mx-auto flex w-full max-w-7xl flex-col items-center justify-center gap-8 px-4 py-24 md:px-24'>
         <Reveal className='flex flex-col items-center gap-8'>
-          <div className='flex items-center gap-4 font-mono text-[2rem] text-blue-500 uppercase lg:text-[2.5rem] dark:text-teal-500'>
+          <h2 className='m-0 flex items-center gap-4 font-mono text-[2rem] font-normal text-blue-500 uppercase lg:text-[2.5rem] dark:text-teal-500'>
             {t('title')}
-          </div>
+          </h2>
           <div className='flex flex-col items-center justify-center gap-12'>
             <div className='flex flex-col'>
               <p className='text-center text-sm md:text-base'>{t('description')}</p>

--- a/src/components/Experience.tsx
+++ b/src/components/Experience.tsx
@@ -29,9 +29,9 @@ const Experience = async () => {
                 />
               </div>
               <div className='flex w-full flex-col'>
-                <p className='mb-6 text-xl font-bold transition duration-200 group-hover:text-blue-500 dark:group-hover:text-teal-500'>
+                <h3 className='m-0 mb-6 text-xl font-bold transition duration-200 group-hover:text-blue-500 dark:group-hover:text-teal-500'>
                   {item.name}
-                </p>
+                </h3>
                 <p className='mb-2'>{t(`list.${item.key}.description-1`)}</p>
                 <p className='mb-6 transition duration-200 group-hover:text-blue-500 dark:group-hover:text-teal-500'>
                   {t(`list.${item.key}.description-2`)}

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -8,7 +8,7 @@ import Reveal from './Reveal';
 
 const Hero = () => {
   const t = useTranslations('hero');
-  const nameRef = useRef<HTMLSpanElement>(null);
+  const nameRef = useRef<HTMLHeadingElement>(null);
 
   useEffect(() => {
     const element = nameRef.current;
@@ -35,12 +35,12 @@ const Hero = () => {
             {t('salutation')}
           </p>
           <div className='mb-2 -ml-[0.15rem] flex'>
-            <span
+            <h1
               ref={nameRef}
-              className='bg-clip-text text-5xl leading-none font-black text-transparent [background-image:linear-gradient(120deg,#5374fa_50%,#64ffda_90%)] md:text-7xl dark:[background-image:linear-gradient(120deg,#64ffda_20%,#5374fa_60%)]'
+              className='m-0 bg-clip-text text-5xl leading-none font-black text-transparent [background-image:linear-gradient(120deg,#5374fa_50%,#64ffda_90%)] md:text-7xl dark:[background-image:linear-gradient(120deg,#64ffda_20%,#5374fa_60%)]'
             >
               {t('name')}.
-            </span>
+            </h1>
           </div>
           <p className='mb-3 -ml-[0.05rem] text-2xl leading-none font-black md:mb-6 md:text-5xl'>
             {t('conclusion')}.

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -21,7 +21,7 @@ const Projects = async ({ projects }: ProjectsProps) => {
           <Reveal key={item.id} delay={index * 100} className='h-full'>
             <div className='group flex h-full flex-col rounded-md bg-[rgba(230,230,230,0.75)] p-8 backdrop-blur-[5px] transition duration-200 hover:-translate-y-1 hover:shadow-xl dark:bg-[rgba(42,42,42,0.75)]'>
               <div className='mb-6 flex items-start justify-between gap-2 transition duration-200 group-hover:text-blue-500 dark:group-hover:text-teal-500'>
-                <p className='text-lg font-bold'>{item.name}</p>
+                <h3 className='m-0 text-lg font-bold'>{item.name}</h3>
                 {!!item.stargazers_count && (
                   <div className='flex items-center gap-2 text-base'>
                     <RiStarLine className='text-xl' />

--- a/src/components/SectionHeader.tsx
+++ b/src/components/SectionHeader.tsx
@@ -5,9 +5,9 @@ type SectionHeaderProps = {
 };
 
 const SectionHeader = ({ children }: SectionHeaderProps) => (
-  <div className='flex rotate-180 items-center gap-4 font-mono text-[1.75rem] text-blue-500 uppercase [writing-mode:vertical-lr] lg:text-[4rem] dark:text-teal-500'>
+  <h2 className='m-0 flex rotate-180 items-center gap-4 font-mono text-[1.75rem] font-normal text-blue-500 uppercase [writing-mode:vertical-lr] lg:text-[4rem] dark:text-teal-500'>
     {children}
-  </div>
+  </h2>
 );
 
 export default SectionHeader;

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -76,7 +76,13 @@
   },
   "notFound": {
     "h1": "The page you are looking for is not available or doesn't belong to this website!",
-    "title": "Page not found"
+    "title": "Page not found",
+    "back": "Back to home"
+  },
+  "error": {
+    "title": "Something went wrong",
+    "description": "An unexpected error occurred. Please try again.",
+    "retry": "Try again"
   },
   "projects": {
     "title": "Projects",

--- a/src/messages/pt.json
+++ b/src/messages/pt.json
@@ -76,7 +76,13 @@
   },
   "notFound": {
     "h1": "A página que você procura não foi encontrada ou não pertence a este website!",
-    "title": "Página não encontrada."
+    "title": "Página não encontrada.",
+    "back": "Voltar ao início"
+  },
+  "error": {
+    "title": "Algo deu errado",
+    "description": "Ocorreu um erro inesperado. Por favor, tente novamente.",
+    "retry": "Tentar novamente"
   },
   "projects": {
     "title": "Projetos",


### PR DESCRIPTION
## a11y

- **Headings semânticos** — a página **não tinha nenhum** heading. Agora: nome do Hero = `<h1>`, títulos de seção (About/Experience/Projects/Contact) = `<h2>`, títulos dos cards = `<h3>`. Verificado: **1 h1 / 4 h2 / 14 h3**.
- **`cursor: pointer` em todo clicável** — os `<button>` nativos (tema, idioma, drawer, logo) ficavam sem pointer depois do reset do Tailwind. Resolvido globalmente no `globals.css` (`button:not(:disabled)`, `[role=button]`, `summary`). _(teu report)_
- **`:focus-visible`** com outline visível (cor de acento, theme-aware) pra navegação por teclado.

## Tratamento de erro (localizado, on-brand, dark)

- **404 localizado** — `[locale]/not-found.tsx` + um catch-all `[locale]/[...rest]` que chama `notFound()`. Sem o catch-all, o next-intl deixa o Next servir o **404 padrão** (foi o que achei acontecendo). Agora URLs inexistentes renderizam o 404 localizado com **status HTTP 404**.
- **Error boundary** — `[locale]/error.tsx` (client) com ação de "tentar novamente".
- Novas chaves `notFound.back` + namespace `error` (en/pt).

## Verificação

- `build` ✅ · `eslint` ✅
- `/pt/pagina-inexistente` → 404 localizado (print conferido), status 404
- Todos os botões do header com `cursor: pointer`; outline no focus

🤖 Generated with [Claude Code](https://claude.com/claude-code)