### PR TITLE
feat(ux): preserve section on language switch + projects fallback

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -8,7 +8,7 @@ import Footer from '../../components/Footer';
 import Header from '../../components/Header';
 import Hero from '../../components/Hero';
 import Projects from '../../components/Projects';
-import { favoriteRepositories, site } from '../../constants';
+import { fallbackRepositories, favoriteRepositories, site } from '../../constants';
 
 const getRepositories = async (): Promise<Repository[]> => {
   try {
@@ -37,6 +37,7 @@ const HomePage = async ({ params }: LocalePageProps) => {
   setRequestLocale(locale);
 
   const repositories = await getRepositories();
+  const projects = repositories.length > 0 ? repositories : fallbackRepositories;
 
   return (
     <>
@@ -46,7 +47,7 @@ const HomePage = async ({ params }: LocalePageProps) => {
         <Hero />
         <About />
         <Experience />
-        {repositories.length > 0 && <Projects projects={repositories} />}
+        <Projects projects={projects} />
         <Contact />
       </main>
       <Footer />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,7 +4,6 @@ import { useLocale, useTranslations } from 'next-intl';
 import { useTheme } from 'next-themes';
 import { RiMoonLine, RiSunLine, RiTranslate } from 'react-icons/ri';
 
-import { usePathname, useRouter } from '../i18n/navigation';
 import { useLogoVisible } from '../store/logo';
 import Drawer from './Drawer';
 import Menu from './Menu';
@@ -12,8 +11,6 @@ import Menu from './Menu';
 const Header = () => {
   const t = useTranslations('header');
   const locale = useLocale();
-  const router = useRouter();
-  const pathname = usePathname();
   const { resolvedTheme, setTheme } = useTheme();
   const logoVisible = useLogoVisible();
 
@@ -21,7 +18,9 @@ const Header = () => {
   const isPt = locale === 'pt';
 
   const toggleLanguage = () => {
-    router.replace(pathname, { locale: isPt ? 'en' : 'pt' });
+    const nextLocale = isPt ? 'en' : 'pt';
+
+    window.location.href = `/${nextLocale}${window.location.hash}`;
   };
 
   return (

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,6 +1,6 @@
 import experience from './experience';
-import favoriteRepositories from './repositories';
+import favoriteRepositories, { fallbackRepositories } from './repositories';
 import site from './site';
 import technologies from './technologies';
 
-export { experience, favoriteRepositories, site, technologies };
+export { experience, fallbackRepositories, favoriteRepositories, site, technologies };

--- a/src/constants/repositories.ts
+++ b/src/constants/repositories.ts
@@ -1,3 +1,5 @@
+import site from './site';
+
 const favoriteRepositories = [
   'evolution-graph',
   'react-boilerplate',
@@ -5,6 +7,53 @@ const favoriteRepositories = [
   'clockify-teams',
   'pure-components',
   'marketmind',
+];
+
+const repoUrl = (name: string) => `https://github.com/${site.githubUsername}/${name}`;
+
+export const fallbackRepositories: Repository[] = [
+  {
+    id: 1,
+    name: 'evolution-graph',
+    language: 'JavaScript',
+    stargazers_count: 0,
+    html_url: repoUrl('evolution-graph'),
+  },
+  {
+    id: 2,
+    name: 'react-boilerplate',
+    language: 'TypeScript',
+    stargazers_count: 0,
+    html_url: repoUrl('react-boilerplate'),
+  },
+  {
+    id: 3,
+    name: 'podjs',
+    language: 'TypeScript',
+    stargazers_count: 0,
+    html_url: repoUrl('podjs'),
+  },
+  {
+    id: 4,
+    name: 'clockify-teams',
+    language: 'JavaScript',
+    stargazers_count: 0,
+    html_url: repoUrl('clockify-teams'),
+  },
+  {
+    id: 5,
+    name: 'pure-components',
+    language: 'TypeScript',
+    stargazers_count: 0,
+    html_url: repoUrl('pure-components'),
+  },
+  {
+    id: 6,
+    name: 'marketmind',
+    language: 'TypeScript',
+    stargazers_count: 0,
+    html_url: repoUrl('marketmind'),
+  },
 ];
 
 export default favoriteRepositories;


### PR DESCRIPTION
## 1. Troca de idioma preserva a seção

Antes, trocar EN↔PT enquanto lia uma seção voltava pro topo. Agora `/en#projects` → **`/pt#projects`** (e rola até lá).

O router do next-intl **descarta o fragmento** (o tipo do href é só `{ pathname, query }`, sem `hash`), então o toggle faz uma navegação completa pra `/${locale}${hash}` — confiável, e o script bloqueante do next-themes evita flash do dark.

**Verificado:** clique real EN→PT em `/en#projects` → `/pt#projects`, `scrollY 3792`, seção Projects no topo.

## 2. Fallback resiliente dos Projects

A seção Projects buscava os repos na API do GitHub (sem auth, 60 req/h por IP). Se batesse rate limit / a API caísse, a seção **sumia inteira** (fallback era `[]`).

Agora há um fallback estático (`constants/repositories.ts`) com os repos favoritos — a seção **sempre renderiza** (as estrelas só somem quando desconhecidas; descrição vem do i18n).

`build` ✅ · `eslint` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)