### PR TITLE
feat(pwa): manifest, generated brand icons, theme-color

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from 'next';
+import type { Metadata, Viewport } from 'next';
 import { hasLocale, NextIntlClientProvider } from 'next-intl';
 import { getTranslations, setRequestLocale } from 'next-intl/server';
 import { Inter, Roboto_Mono } from 'next/font/google';
@@ -18,6 +18,10 @@ const robotoMono = Roboto_Mono({
 });
 
 const ogLocales: Record<string, string> = { en: 'en_US', pt: 'pt_BR' };
+
+export const viewport: Viewport = {
+  themeColor: '#222222',
+};
 
 export const generateMetadata = async ({ params }: LocalePageProps): Promise<Metadata> => {
   const { locale } = await params;

--- a/src/app/apple-icon.tsx
+++ b/src/app/apple-icon.tsx
@@ -1,0 +1,36 @@
+import { ImageResponse } from 'next/og';
+
+export const size = { width: 180, height: 180 };
+export const contentType = 'image/png';
+
+const AppleIcon = () =>
+  new ImageResponse(
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: '#222222',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          fontSize: 130,
+          fontWeight: 800,
+          fontFamily: 'sans-serif',
+          color: 'transparent',
+          backgroundImage: 'linear-gradient(120deg, #64ffda 20%, #5374fa 70%)',
+          backgroundClip: 'text',
+          WebkitBackgroundClip: 'text',
+        }}
+      >
+        N
+      </div>
+    </div>,
+    size,
+  );
+
+export default AppleIcon;

--- a/src/app/icon.tsx
+++ b/src/app/icon.tsx
@@ -1,0 +1,36 @@
+import { ImageResponse } from 'next/og';
+
+export const size = { width: 512, height: 512 };
+export const contentType = 'image/png';
+
+const Icon = () =>
+  new ImageResponse(
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: '#222222',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          fontSize: 380,
+          fontWeight: 800,
+          fontFamily: 'sans-serif',
+          color: 'transparent',
+          backgroundImage: 'linear-gradient(120deg, #64ffda 20%, #5374fa 70%)',
+          backgroundClip: 'text',
+          WebkitBackgroundClip: 'text',
+        }}
+      >
+        N
+      </div>
+    </div>,
+    size,
+  );
+
+export default Icon;

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -1,0 +1,19 @@
+import type { MetadataRoute } from 'next';
+
+import site from '../constants/site';
+
+const manifest = (): MetadataRoute.Manifest => ({
+  name: site.name,
+  short_name: 'Nathan',
+  description: 'Portfolio of Nathan S. Santos — Software Engineer.',
+  start_url: '/',
+  display: 'standalone',
+  background_color: '#222222',
+  theme_color: '#222222',
+  icons: [
+    { src: '/icon', sizes: '512x512', type: 'image/png', purpose: 'any' },
+    { src: '/apple-icon', sizes: '180x180', type: 'image/png' },
+  ],
+});
+
+export default manifest;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -5,5 +5,5 @@ import { routing } from './i18n/routing';
 export default createMiddleware(routing);
 
 export const config = {
-  matcher: ['/((?!api|_next|_vercel|.*\\..*).*)'],
+  matcher: ['/((?!api|_next|_vercel|icon|apple-icon|manifest|sitemap|robots|.*\\..*).*)'],
 };


### PR DESCRIPTION
Nice-to-have: torna o portfólio um PWA instalável e melhora o ícone/chrome.

- **`icon.tsx` + `apple-icon.tsx`** — geram o "N" em gradiente (next/og) como PNG 512/180: favicon moderno + apple-touch-icon, batendo com o logo do header
- **`manifest.ts`** — nome, `standalone`, cores dark, ícones → instalável, linkado no `<head>`
- **`theme-color` (#222)** via export `viewport` — o chrome do browser mobile combina com o dark forçado
- **Fix de bug**: as rotas de metadata na raiz (`/icon`, `/apple-icon`) não têm ponto, então o matcher do proxy do next-intl as redirecionava pra `/en/icon` → **404** (quebrava o favicon). Excluídas do matcher.

**Verificação:** `/icon` e `/apple-icon` → `200 image/png`; `/manifest.webmanifest`, `/sitemap.xml`, `/robots.txt`, `/en` → 200. `build` ✅ · `eslint` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)