### PR TITLE
perf: defer particles background (dynamic import)

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,7 +1,7 @@
 import { setRequestLocale } from 'next-intl/server';
 
 import About from '../../components/About';
-import Background from '../../components/Background';
+import BackgroundLoader from '../../components/BackgroundLoader';
 import Contact from '../../components/Contact';
 import Experience from '../../components/Experience';
 import Footer from '../../components/Footer';
@@ -43,7 +43,7 @@ const HomePage = async ({ params }: LocalePageProps) => {
     <>
       <Header />
       <main>
-        <Background />
+        <BackgroundLoader />
         <Hero />
         <About />
         <Experience />

--- a/src/components/BackgroundLoader.tsx
+++ b/src/components/BackgroundLoader.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+
+const Background = dynamic(() => import('./Background'), { ssr: false });
+
+const BackgroundLoader = () => <Background />;
+
+export default BackgroundLoader;


### PR DESCRIPTION
Nice-to-have de performance.

O `tsparticles` é um chunk considerável que só serve pra um fundo decorativo. Agora ele carrega **lazy** via `next/dynamic({ ssr: false })` num wrapper client (`BackgroundLoader`), saindo do JS crítico da rota e montando após a hidratação.

**Verificado:** o canvas (fixed, z-index -1, fullscreen) segue renderizando idêntico; chunk das partículas agora é carregado após o load inicial. `build` ✅ · `eslint` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)