### PR TITLE
content(hero): drop 'design systems / AI-assisted' from the intro

### DIFF
--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -68,7 +68,7 @@
     "name": "Nathan",
     "conclusion": "I build digital experiences",
     "description": "I’m a fullstack software engineer with 7+ years of experience building high-performance web and desktop applications.",
-    "description-2": "Specialized in React, TypeScript, and Node.js, with a focus on design systems and AI-assisted development — currently open to new opportunities."
+    "description-2": "Specialized in React, TypeScript, and Node.js — currently open to new opportunities."
   },
   "metadata": {
     "title": "Nathan S. Santos — Software Engineer",

--- a/src/messages/pt.json
+++ b/src/messages/pt.json
@@ -68,7 +68,7 @@
     "name": "Nathan",
     "conclusion": "Eu crio experiências digitais",
     "description": "Sou um desenvolvedor de software fullstack com mais de 7 anos de experiência construindo aplicações web e desktop de alta performance.",
-    "description-2": "Especializado em React, TypeScript e Node.js, com foco em design systems e desenvolvimento potencializado por IA — atualmente aberto a novas oportunidades."
+    "description-2": "Especializado em React, TypeScript e Node.js — atualmente aberto a novas oportunidades."
   },
   "metadata": {
     "title": "Nathan S. Santos — Engenheiro de Software",


### PR DESCRIPTION
Ajuste de copy do Hero: a 2ª linha volta pra versão mais limpa de abril/2026 (`99097ff`), tirando o trecho "with a focus on design systems and AI-assisted development" (EN e PT).

Fica: **Specialized in React, TypeScript, and Node.js — currently open to new opportunities.** / **Especializado em React, TypeScript e Node.js — atualmente aberto a novas oportunidades.**

`build` ✅ · `eslint` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)