### PR TITLE
fix(header): show the logo when the hero is out of view

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -16,7 +16,7 @@ const Hero = () => {
     if (!element) return;
 
     const observer = new IntersectionObserver(
-      ([entry]) => setLogoVisible(entry.isIntersecting),
+      ([entry]) => setLogoVisible(!entry.isIntersecting),
       {
         threshold: 0,
       },


### PR DESCRIPTION
O "N" no header estava com a lógica invertida — aparecia enquanto o nome do Hero estava na tela e sumia ao rolar. Corrigido pra aparecer **só quando o Hero sai da viewport** (`!entry.isIntersecting`).

Verificado no browser: no topo o logo fica `opacity: 0`; após rolar além do Hero, `opacity: 1`. `build` ✅ · `eslint` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)